### PR TITLE
Bugfix/inject tenantfilter always

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.18.2</VersionPrefix>
+    <VersionPrefix>1.18.3</VersionPrefix>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## [1.19.0] - 2020-12-06
+
+### Change
+- breaking change: TenantRepositoryFilter gets injected always, but uses now only Lazy<ITenantContext> - fixes issue when first request didn't have the filter applied (hint: use ExcludeFilters method when implementing a custom ITenantProvider)
+
 ## [1.18.2] - 2020-11-20
 
 ### Fixed

--- a/Revo.DataAccess/Entities/ReadRepositoryExtensions.cs
+++ b/Revo.DataAccess/Entities/ReadRepositoryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Revo.DataAccess.Entities
 {
@@ -16,6 +17,35 @@ namespace Revo.DataAccess.Entities
             }
 
             return (T) filteringRepository.IncludeFilters(repositoryFilters);
+        }
+
+        public static T ExcludeFilters<T>(this T repository,
+            params IRepositoryFilter[] repositoryFilters) where T : IReadRepository
+        {
+            IFilteringRepository<IReadRepository> filteringRepository =
+                repository as IFilteringRepository<IReadRepository>;
+            if (filteringRepository == null)
+            {
+                throw new ArgumentException(
+                    $"Repository type {repository.GetType().FullName} does not implement IFilteringRepository<>");
+            }
+
+            return (T)filteringRepository.ExcludeFilter(repositoryFilters);
+        }
+
+        public static T ExcludeFilters<T>(this T repository,
+            params Type[] repositoryFilterTypes) where T : IReadRepository
+        {
+            IFilteringRepository<IReadRepository> filteringRepository =
+                repository as IFilteringRepository<IReadRepository>;
+            if (filteringRepository == null)
+            {
+                throw new ArgumentException(
+                    $"Repository type {repository.GetType().FullName} does not implement IFilteringRepository<>");
+            }
+
+            var filters = repository.DefaultFilters.Where(x => repositoryFilterTypes.Any(y => y.IsInstanceOfType(x)));
+            return (T)filteringRepository.ExcludeFilter(filters.ToArray());
         }
     }
 }

--- a/Revo.Infrastructure/Tenancy/DefaultTenantContext.cs
+++ b/Revo.Infrastructure/Tenancy/DefaultTenantContext.cs
@@ -1,4 +1,5 @@
-﻿using Revo.Core.Tenancy;
+﻿using Revo.Core.Core;
+using Revo.Core.Tenancy;
 using Revo.Domain.Tenancy;
 
 namespace Revo.Infrastructure.Tenancy

--- a/Revo.Infrastructure/Tenancy/TenancyModule.cs
+++ b/Revo.Infrastructure/Tenancy/TenancyModule.cs
@@ -24,7 +24,6 @@ namespace Revo.Infrastructure.Tenancy
             {
                 Bind<IRepositoryFilter>()
                     .To<TenantRepositoryFilter>()
-                    .WhenNoAncestorMatches(ctx => typeof(ITenantProvider).IsAssignableFrom(ctx.Request.Service))
                     .InTransientScope()
                     .WithPropertyValue(nameof(TenantRepositoryFilter.NullTenantCanAccessOtherTenantsData), configuration.NullTenantCanAccessOtherTenantsData);
             }

--- a/Revo.Infrastructure/Tenancy/TenantRepositoryFilter.cs
+++ b/Revo.Infrastructure/Tenancy/TenantRepositoryFilter.cs
@@ -7,9 +7,9 @@ namespace Revo.Infrastructure.Tenancy
 {
     public class TenantRepositoryFilter : IRepositoryFilter
     {
-        private readonly ITenantContext tenantContext;
+        private readonly Lazy<ITenantContext> tenantContext;
 
-        public TenantRepositoryFilter(ITenantContext tenantContext)
+        public TenantRepositoryFilter(Lazy<ITenantContext> tenantContext)
         {
             this.tenantContext = tenantContext;
         }
@@ -31,7 +31,7 @@ namespace Revo.Infrastructure.Tenancy
             ITenantOwned tenantOwned = result as ITenantOwned;
             if (tenantOwned != null)
             {
-                Guid? tenantId = tenantContext.Tenant?.Id;
+                Guid? tenantId = tenantContext.Value.Tenant?.Id;
                 if (tenantOwned.TenantId != null
                     && (!NullTenantCanAccessOtherTenantsData || tenantId != null)
                     && tenantOwned.TenantId != tenantId)
@@ -48,7 +48,7 @@ namespace Revo.Infrastructure.Tenancy
             ITenantOwned tenantOwned = added as ITenantOwned;
             if (tenantOwned != null)
             {
-                Guid? tenantId = tenantContext.Tenant?.Id;
+                Guid? tenantId = tenantContext.Value.Tenant?.Id;
                 if (tenantOwned.TenantId != null
                     && (!NullTenantCanAccessOtherTenantsData || tenantId != null)
                     && tenantOwned.TenantId != tenantId)
@@ -64,7 +64,7 @@ namespace Revo.Infrastructure.Tenancy
             ITenantOwned tenantOwned = deleted as ITenantOwned;
             if (tenantOwned != null)
             {
-                Guid? tenantId = tenantContext.Tenant?.Id;
+                Guid? tenantId = tenantContext.Value.Tenant?.Id;
                 if (tenantOwned.TenantId != null
                     && (!NullTenantCanAccessOtherTenantsData || tenantId != null)
                     && tenantOwned.TenantId != tenantId)
@@ -80,7 +80,7 @@ namespace Revo.Infrastructure.Tenancy
             ITenantOwned tenantOwned = modified as ITenantOwned;
             if (tenantOwned != null)
             {
-                Guid? tenantId = tenantContext.Tenant?.Id;
+                Guid? tenantId = tenantContext.Value.Tenant?.Id;
                 if (tenantOwned.TenantId != null
                     && (!NullTenantCanAccessOtherTenantsData || tenantId != null)
                     && tenantOwned.TenantId != tenantId)
@@ -93,7 +93,7 @@ namespace Revo.Infrastructure.Tenancy
 
         private IQueryable<T> DoFilterResults<T>(IQueryable<T> results) where T : class, ITenantOwned
         {
-            Guid? tenantId = tenantContext.Tenant?.Id;
+            Guid? tenantId = tenantContext.Value.Tenant?.Id;
             if (tenantId == null && NullTenantCanAccessOtherTenantsData)
             {
                 return results;

--- a/Tests/Revo.Infrastructure.Tests/Tenancy/TenantRepositoryFilterTests.cs
+++ b/Tests/Revo.Infrastructure.Tests/Tenancy/TenantRepositoryFilterTests.cs
@@ -39,7 +39,7 @@ namespace Revo.Infrastructure.Tests.Tenancy
 
             tenant = Substitute.For<ITenant>();
 
-            sut = new TenantRepositoryFilter(tenantContext);
+            sut = new TenantRepositoryFilter(new Lazy<ITenantContext>(() => tenantContext));
         }
 
         [Fact]


### PR DESCRIPTION
Breaking change: TenantRepositoryFilter gets injected always, but uses now only Lazy<ITenantContext> - fixes issue when first request didn't have the filter applied (hint: use ExcludeFilters method when implementing a custom ITenantProvider)