### PR TITLE
Bugfix: external events enqueued twice

### DIFF
--- a/Providers/EFCore/Revo.EFCore/DataAccess/Entities/EFCoreCrudRepository.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Entities/EFCoreCrudRepository.cs
@@ -371,7 +371,8 @@ namespace Revo.EFCore.DataAccess.Entities
 
         public bool IsAttached<T>(T entity) where T : class
         {
-            return DatabaseAccess.GetDbContext(typeof(T)).Set<T>().Local.Any(x => x == entity);
+            return DatabaseAccess.GetDbContext(typeof(T)).Entry(entity).State !=
+                   Microsoft.EntityFrameworkCore.EntityState.Detached;
         }
 
         public IEFCoreCrudRepository IncludeFilters(params IRepositoryFilter[] repositoryFilters)

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Entities/RequestDbContextCache.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Entities/RequestDbContextCache.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
 namespace Revo.EFCore.DataAccess.Entities

--- a/Providers/EFCore/Revo.EFCore/Projections/EFCoreProjectionEventListener.cs
+++ b/Providers/EFCore/Revo.EFCore/Projections/EFCoreProjectionEventListener.cs
@@ -42,8 +42,8 @@ namespace Revo.EFCore.Projections
                     ? entityTypeManager.TryGetClassInfoByClassId(aggregateClassId.Value)
                     : null;
                 
-                if (classInfo == null
-                    || projectorResolver.HasAnyProjectors(classInfo.ClrType))
+                if (classInfo != null
+                    && projectorResolver.HasAnyProjectors(classInfo.ClrType))
                 {
                     yield return new EventSequencing()
                     {

--- a/Providers/EFCore/Revo.EFCore/Repositories/EFCoreCoordinatedTransaction.cs
+++ b/Providers/EFCore/Revo.EFCore/Repositories/EFCoreCoordinatedTransaction.cs
@@ -49,14 +49,14 @@ namespace Revo.EFCore.Repositories
                     case EFCoreProjectionSubSystem _:
                         return 103;
 
+                    case EFCoreAsyncEventQueueManager _:
+                        return 104;
+
                     case EFCoreEventStore _:
                         return 105;
 
                     case EFCoreExternalEventStore _:
                         return 106;
-
-                    case EFCoreAsyncEventQueueManager _:
-                        return 107;
 
                     default:
                         return 0;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,12 +7,16 @@
 - transactionMode for database migrations (isolated, without) for overriding their transaction behavior
 
 ### Fixed
-- ExternalEventSourceCatchUp should dispatch messages with metadata mapped from the event record (e.g. ID) + added test
+- ExternalEventSourceCatchUp should dispatch messages with metadata mapped from the event record (e.g. ID)
+- async events might occasionally have gotten enqueued twice during EF Core's coordinated transaction
 
 ### Changed
 - database migrations are run inside a unit of work when using EF Core and EF6 providers
 - EF Core/EF6 migration providers no longer create database upon startup
 - renamed lifecycle hook interfaces (IApplicationStartedListener, IApplicationStoppingListener) and added new IApplicationStartingListener hook
+
+### Improved
+- better performance when enqueueing async events & for EFCoreCrudRepository.IsAttached
 
 ## [1.22.0] - 2020-04-30
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,9 @@
 - database migration hooks - can now listen to events like DatabaseMigrationBeforeAppliedEvent, DatabaseMigrationAppliedEvent and DatabaseMigrationsCommittedEvent
 - transactionMode for database migrations (isolated, without) for overriding their transaction behavior
 
+### Fixed
+- ExternalEventSourceCatchUp should dispatch messages with metadata mapped from the event record (e.g. ID) + added test
+
 ### Changed
 - database migrations are run inside a unit of work when using EF Core and EF6 providers
 - EF Core/EF6 migration providers no longer create database upon startup

--- a/Revo.Core/Commands/CommandBusPipeline.cs
+++ b/Revo.Core/Commands/CommandBusPipeline.cs
@@ -24,7 +24,7 @@ namespace Revo.Core.Commands
         public Task<object> ProcessAsync(ICommandBase command, CommandBusMiddlewareDelegate executionHandler,
             ICommandBus commandBus, CommandExecutionOptions executionOptions, CancellationToken cancellationToken)
         {
-            var processMethod = GetType().GetRuntimeMethods().Single(x => x.Name == "ProcessInternalAsync");
+            var processMethod = GetType().GetRuntimeMethods().Single(x => x.Name == nameof(ProcessInternalAsync));
             var boundProcessMethod = processMethod.MakeGenericMethod(command.GetType());
 
             return (Task<object>)boundProcessMethod.Invoke(this, new object[]

--- a/Revo.Core/Core/TaskFactoryExtensions.cs
+++ b/Revo.Core/Core/TaskFactoryExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Revo.Core.Core

--- a/Revo.Infrastructure/EventStores/Generic/ExternalEventSourceCatchUp.cs
+++ b/Revo.Infrastructure/EventStores/Generic/ExternalEventSourceCatchUp.cs
@@ -33,12 +33,7 @@ namespace Revo.Infrastructure.EventStores.Generic
             if (nondispatchedEvents.Count > 0)
             {
                 var messages = nondispatchedEvents.Select(x =>
-                {
-                    var @event = eventSerializer.DeserializeEvent(x.EventJson,
-                        new VersionedTypeId(x.EventName, x.EventVersion));
-                    var metadata = eventSerializer.DeserializeEventMetadata(x.MetadataJson);
-                    return EventMessage.FromEvent(@event, metadata);
-                });
+                    ExternalEventMessageAdapter.FromRecord(x, eventSerializer));
 
                 await asyncEventQueueDispatcher.DispatchToQueuesAsync(messages, null, null);
             }

--- a/Revo.Infrastructure/EventStores/Generic/ExternalEventStore.cs
+++ b/Revo.Infrastructure/EventStores/Generic/ExternalEventStore.cs
@@ -52,8 +52,7 @@ namespace Revo.Infrastructure.EventStores.Generic
         protected virtual async Task<ExternalEventRecord[]> GetExistingEventRecordsAsync(Guid[] ids)
         {
             return await crudRepository
-                .Where<ExternalEventRecord>(x => ids.Contains(x.Id))
-                .ToArrayAsync(crudRepository);
+                .FindManyAsync<ExternalEventRecord>(ids);
         }
 
         protected async Task<ExternalEventRecord[]> PrepareRecordsAsync()

--- a/Revo.Infrastructure/Events/Async/Generic/AsyncEventQueueManager.cs
+++ b/Revo.Infrastructure/Events/Async/Generic/AsyncEventQueueManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MoreLinq;
 using Revo.Core.Events;
 using Revo.DataAccess.Entities;
 using Revo.Domain.Events;
@@ -133,7 +134,6 @@ namespace Revo.Infrastructure.Events.Async.Generic
             await EnqueueExternalEventsAsync(queuedEvents);
             await CreateQueuesAsync(queuedEvents);
             
-            eventsToQueues.Clear();
             return queuedEvents;
         }
 
@@ -155,9 +155,10 @@ namespace Revo.Infrastructure.Events.Async.Generic
         private void EnqueueEventStoreEvents(List<QueuedAsyncEvent> queuedEvents)
         {
             // all event store events need to be marked as dispatched (even whey they haven't been dispatched to any queues)
-            var eventStoreEvents = eventsToQueues.Where(x =>
-                (x.Key as IEventStoreEventMessage)?.Record is IEventStreamRowEventStoreRecord).ToArray();
-
+            var eventStoreEvents = eventsToQueues
+                .Where(x => (x.Key as IEventStoreEventMessage)?.Record is IEventStreamRowEventStoreRecord)
+                .ToArray();
+            
             foreach (var eventToQueues in eventStoreEvents)
             {
                 var storeMessage = (IEventStoreEventMessage)eventToQueues.Key;
@@ -169,11 +170,7 @@ namespace Revo.Infrastructure.Events.Async.Generic
 
                 eventStreamRow.MarkDispatchedToAsyncQueues();
 
-                if (!crudRepository.IsAttached(eventStreamRow))
-                {
-                    crudRepository.Attach(eventStreamRow);
-                    crudRepository.SetEntityState(eventStreamRow, EntityState.Modified);
-                }
+                crudRepository.SetEntityState(eventStreamRow, EntityState.Modified);
 
                 var eventSequencings = eventToQueues.Value;
                 if (eventSequencings != null)
@@ -187,6 +184,8 @@ namespace Revo.Infrastructure.Events.Async.Generic
                     }
                 }
             }
+            
+            eventStoreEvents.ForEach(x => eventsToQueues.Remove(x.Key));
         }
 
         private async Task EnqueueExternalEventsAsync(List<QueuedAsyncEvent> queuedEvents)
@@ -202,11 +201,20 @@ namespace Revo.Infrastructure.Events.Async.Generic
                     var eventId = x.Key.Metadata.GetEventId();
                     if (eventId == null)
                     {
-                        return new KeyValuePair<IEventMessage, List<EventSequencing>>(
-                            CloneMessageWithId(x.Key), x.Value);
+                        return new
+                        {
+                            OriginalMessage = x.Key,
+                            Message = CloneMessageWithId(x.Key),
+                            EventSequencings = x.Value
+                        };
                     }
 
-                    return x;
+                    return new
+                    {
+                        OriginalMessage = x.Key,
+                        Message = x.Key,
+                        EventSequencings = x.Value
+                    };
                 })
                 .ToArray();
             
@@ -214,7 +222,8 @@ namespace Revo.Infrastructure.Events.Async.Generic
             {
                 foreach (var externalEvent in externalEvents)
                 {
-                    externalEventStore.TryPushEvent(externalEvent.Key);
+                    externalEventStore.TryPushEvent(externalEvent.Message);
+                    eventsToQueues.Remove(externalEvent.OriginalMessage); // we need to remove the events before the CommitAsync below, which might trigger another execution of this method
                 }
 
                 var externalEventRecords = await externalEventStore.CommitAsync();
@@ -226,14 +235,15 @@ namespace Revo.Infrastructure.Events.Async.Generic
                     }
 
                     externalEventRecord.MarkDispatchedToAsyncQueues();
+                    
+                    crudRepository.SetEntityState(externalEventRecord, EntityState.Modified);
 
-                    if (!crudRepository.IsAttached(externalEventRecord))
+                    var sequencings = externalEvents.FirstOrDefault(x =>
+                        x.Message.Metadata.GetEventId() == externalEventRecord.Id)?.EventSequencings;
+                    if (sequencings == null) // may happen with providers like EF Core with coordinated transactions
                     {
-                        crudRepository.Attach(externalEventRecord);
-                        crudRepository.SetEntityState(externalEventRecord, EntityState.Modified);
+                        continue;
                     }
-
-                    var sequencings = externalEvents.First(x => x.Key.Metadata.GetEventId() == externalEventRecord.Id).Value;
 
                     foreach (var sequencing in sequencings)
                     {

--- a/Revo.Infrastructure/Events/Async/Generic/ExternalEventRecord.cs
+++ b/Revo.Infrastructure/Events/Async/Generic/ExternalEventRecord.cs
@@ -6,7 +6,7 @@ namespace Revo.Infrastructure.Events.Async.Generic
 {
     [TablePrefix(NamespacePrefix = "RAE", ColumnPrefix = "EER")]
     [DatabaseEntity]
-    public class ExternalEventRecord
+    public class ExternalEventRecord : IHasId<Guid>
     {
         public ExternalEventRecord(Guid id, string eventJson, string eventName, int eventVersion,
             string metadataJson)

--- a/Revo.Infrastructure/Projections/ProjectionSubSystem.cs
+++ b/Revo.Infrastructure/Projections/ProjectionSubSystem.cs
@@ -30,7 +30,8 @@ namespace Revo.Infrastructure.Projections
 
             foreach (var entityEvents in aggregateEvents)
             {
-                Guid classId = entityEvents.First().Metadata.GetAggregateClassId() ?? throw new InvalidOperationException($"Cannot create projection for aggregate ID {entityEvents.Key} because event metadata don't contain aggregate class ID");
+                Guid classId = entityEvents.First().Metadata.GetAggregateClassId()
+                               ?? throw new InvalidOperationException($"Cannot create projection for aggregate ID {entityEvents.Key} because event metadata don't contain aggregate class ID");
                 Type entityType = entityTypeManager.GetClassInfoByClassId(classId).ClrType;
 
                 Guid aggregateId = entityEvents.Key;

--- a/Tests/Revo.Infrastructure.Tests/EventStores/Generic/ExternalEventSourceCatchUpTests.cs
+++ b/Tests/Revo.Infrastructure.Tests/EventStores/Generic/ExternalEventSourceCatchUpTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using Revo.Core.Events;
+using Revo.Core.Types;
+using Revo.DataAccess.Entities;
+using Revo.DataAccess.InMemory;
+using Revo.Domain.Events;
+using Revo.Infrastructure.Events;
+using Revo.Infrastructure.Events.Async;
+using Revo.Infrastructure.Events.Async.Generic;
+using Revo.Infrastructure.EventStores.Generic;
+using Xunit;
+
+namespace Revo.Infrastructure.Tests.EventStores.Generic
+{
+    public class ExternalEventSourceCatchUpTests
+    {
+        private ExternalEventSourceCatchUp sut;
+        private InMemoryCrudRepository crudRepository;
+        private IAsyncEventQueueDispatcher asyncEventQueueDispatcher;
+        private IEventSerializer eventSerializer;
+        private IEventMessage[] dispatchedMessages;
+
+        public ExternalEventSourceCatchUpTests()
+        {
+            crudRepository = new InMemoryCrudRepository();
+            asyncEventQueueDispatcher = Substitute.For<IAsyncEventQueueDispatcher>();
+            eventSerializer = Substitute.For<IEventSerializer>();
+
+            eventSerializer.DeserializeEvent("{}", new VersionedTypeId("TestEvent", 1))
+                .Returns(new TestEvent());
+
+            asyncEventQueueDispatcher.WhenForAnyArgs(x => x.DispatchToQueuesAsync(null, null, null))
+                .Do(ci => dispatchedMessages = ci.Arg<IEnumerable<IEventMessage>>().ToArray());
+
+            sut = new ExternalEventSourceCatchUp(crudRepository, asyncEventQueueDispatcher,
+                eventSerializer);
+        }
+
+        [Fact]
+        public async Task CatchUpAsync_Dispatches()
+        {
+            var events = new[]
+            {
+                new ExternalEventRecord(Guid.Parse("C4BFAF3B-2B5D-461B-8284-70EFA32FC025"), "{}", "TestEvent", 1, "{}")
+            };
+            crudRepository.AttachRange(events);
+
+            await sut.CatchUpAsync();
+            asyncEventQueueDispatcher.ReceivedWithAnyArgs(1).DispatchToQueuesAsync(null, null, null);
+            dispatchedMessages.Should().HaveCount(1);
+            dispatchedMessages[0].Event.Should().BeOfType<TestEvent>();
+            dispatchedMessages[0].Metadata.Should().NotBeNullOrEmpty();
+            dispatchedMessages[0].Metadata.GetEventId().Should().Be(events[0].Id);
+        }
+        
+        [Fact]
+        public async Task CatchUpAsync_IgnoreAlreadyDispatched()
+        {
+            var events = new[]
+            {
+                new ExternalEventRecord(Guid.Parse("C4BFAF3B-2B5D-461B-8284-70EFA32FC025"), "{}", "TestEvent", 1, "{}")
+            };
+            events[0].MarkDispatchedToAsyncQueues();
+            crudRepository.AttachRange(events);
+
+            await sut.CatchUpAsync();
+            asyncEventQueueDispatcher.DidNotReceiveWithAnyArgs().DispatchToQueuesAsync(null, null, null);
+        }
+
+        private class TestEvent : IEvent
+        {
+        }
+    }
+}


### PR DESCRIPTION
-fixed: async events might occasionally have gotten enqueued twice during EF Core's coordinated transaction
-improved: better performance when enqueueing async events & for EFCoreCrudRepository.IsAttached
-fixed: ExternalEventSourceCatchUp should dispatch messages with metadata mapped from the event record (e.g. ID)