### PR TITLE
Event catch-ups not blocking application startup

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.23.0</VersionPrefix>
+    <VersionPrefix>1.24.0</VersionPrefix>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/Providers/EasyNetQ/Revo.EasyNetQ/BusInitializer.cs
+++ b/Providers/EasyNetQ/Revo.EasyNetQ/BusInitializer.cs
@@ -6,8 +6,7 @@ using Revo.EasyNetQ.Configuration;
 
 namespace Revo.EasyNetQ
 {
-    public class BusInitializer :
-        IApplicationStartedListener,
+    public class BusInitializer : IApplicationStartedListener,
         IApplicationStoppingListener
     {
         private readonly IBus bus;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## [1.24.0] - 2020-06-08
+
+### Changed
+- by default, event source and event queue catch-ups now don't block application startup until finished (IAsyncEventPipelineConfiguration.WaitForEventCatchUpsUponStartup)
+
 ## [1.23.0] - 2020-05-19
 
 ### Added

--- a/Revo.Infrastructure/Events/Async/AsyncEventExecutionCatchUp.cs
+++ b/Revo.Infrastructure/Events/Async/AsyncEventExecutionCatchUp.cs
@@ -30,7 +30,12 @@ namespace Revo.Infrastructure.Events.Async
 
         public void OnApplicationStarted()
         {
-            Task.Run(InitializeAsync).GetAwaiter().GetResult();
+            var task = Task.Run(InitializeAsync);
+
+            if (asyncEventPipelineConfiguration.WaitForEventCatchUpsUponStartup)
+            {
+                task.GetAwaiter().GetResult();
+            }
         }
 
         private async Task InitializeAsync()

--- a/Revo.Infrastructure/Events/Async/AsyncEventPipelineConfiguration.cs
+++ b/Revo.Infrastructure/Events/Async/AsyncEventPipelineConfiguration.cs
@@ -11,7 +11,8 @@ namespace Revo.Infrastructure.Events.Async
         public TimeSpan AsyncRescheduleDelayAfterSyncProcessFailure { get; set; } = TimeSpan.FromMinutes(1);
         public TimeSpan AsyncProcessRetryTimeout { get; set; } = TimeSpan.FromMilliseconds(500);
         public int AsyncProcessRetryTimeoutMultiplier { get; set; } = 6;
-        
+        public bool WaitForEventCatchUpsUponStartup { get; set; } = false;
+
         public int SyncProcessAttemptCount { get; set; } = 3;
         public TimeSpan SyncProcessRetryTimeout { get; set; } = TimeSpan.FromMilliseconds(500);
         public int SyncProcessRetryTimeoutMultiplier { get; set; } = 4;

--- a/Revo.Infrastructure/Events/Async/IAsyncEventPipelineConfiguration.cs
+++ b/Revo.Infrastructure/Events/Async/IAsyncEventPipelineConfiguration.cs
@@ -20,7 +20,7 @@ namespace Revo.Infrastructure.Events.Async
         int SyncQueueProcessingParallelism { get; }
 
         /// <summary>
-        /// Maximum total nnumber of Tasks to be run in parallel by the event daemon when asynchronously processing event queues.
+        /// Maximum total number of Tasks to be run in parallel by the event daemon when asynchronously processing event queues.
         /// Does not directly influence the amount of threads spawned, only limits the number of unfinished processing tasks at a time.
         /// </summary>
         //int AsyncQueueProcessingParallelism { get; }
@@ -29,6 +29,7 @@ namespace Revo.Infrastructure.Events.Async
         TimeSpan AsyncRescheduleDelayAfterSyncProcessFailure { get; }
         TimeSpan AsyncProcessRetryTimeout { get; }
         int AsyncProcessRetryTimeoutMultiplier { get; }
+        bool WaitForEventCatchUpsUponStartup { get; }
 
         int SyncProcessAttemptCount { get; }
         TimeSpan SyncProcessRetryTimeout { get; }


### PR DESCRIPTION
-event source and event queue catch-ups now don't block application startup until finished by default (IAsyncEventPipelineConfiguration.WaitForEventCatchUpsUponStartup), closes #6
-bumped version to 1.24.0