### PR TITLE
bugfix: default EasyNetQ subscription AddType configuration callback

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.26.0</VersionPrefix>
+    <VersionPrefix>1.26.1</VersionPrefix>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/Providers/EasyNetQ/Revo.EasyNetQ/BusInitializer.cs
+++ b/Providers/EasyNetQ/Revo.EasyNetQ/BusInitializer.cs
@@ -64,7 +64,7 @@ namespace Revo.EasyNetQ
 
             await bus.PubSub.SubscribeAsync(subscriptionConfiguration.SubscriptionId,
                 onMessage,
-                subscriptionConfiguration.ConfigurationAction);
+                subscriptionConfiguration.ConfigurationAction ?? (_ => { }));
         }
 
         private async Task Subscribe<T>(EasyNetQSubscriptionsConfiguration.SubscriptionConfiguration subscriptionConfiguration)
@@ -72,7 +72,7 @@ namespace Revo.EasyNetQ
         {
             await bus.PubSub.SubscribeAsync<IEventMessage<T>>(subscriptionConfiguration.SubscriptionId,
                 (e, c) => subscriptionHandler.HandleMessageAsync(e),
-                subscriptionConfiguration.ConfigurationAction);
+                subscriptionConfiguration.ConfigurationAction ?? (_ => { }));
         }
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## [1.26.1] - 2020-10-21
+
+### Fixed
+
+- EasyNetQ subscription AddType configuration should provide default empty configuration callback when passed null
+
 ## [1.26.0] - 2020-10-20
 
 ### Added


### PR DESCRIPTION
EasyNetQ subscription AddType configuration should provide default empty configuration callback when passed null