### PR TITLE
Bugfix/buffered notification store duplicates

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.28.0</VersionPrefix>
+    <VersionPrefix>1.28.1</VersionPrefix>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/Extensions/Tests/Revo.Extensions.Notifications.Tests/Channels/Bufferring/BufferedNotificationStoreTests.cs
+++ b/Extensions/Tests/Revo.Extensions.Notifications.Tests/Channels/Bufferring/BufferedNotificationStoreTests.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using FluentAssertions;
+using MoreLinq;
 using NSubstitute;
 using Revo.DataAccess.InMemory;
 using Revo.Extensions.Notifications.Channels.Buffering;
 using Revo.Extensions.Notifications.Model;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Revo.Extensions.Notifications.Tests.Channels.Bufferring
@@ -32,33 +34,50 @@ namespace Revo.Extensions.Notifications.Tests.Channels.Bufferring
             await sut.Add(new SerializedNotification() { NotificationClassName = "Notification1", NotificationJson = "{}" },
                 buffer.Name, now, "governor1", "pipeline1");
 
-            Assert.Equal(1, inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>().Count());
-            Assert.Single(inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>(),
-                x => x.NotificationClassName == "Notification1"
-                     && x.NotificationJson == "{}"
-                     && x.Buffer == buffer
-                     && x.TimeQueued == now
-                     && x.Id != Guid.Empty);
-            Assert.Equal(1, inMemoryCrudRepository.FindAll<NotificationBuffer>().Count());
+            inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>()
+                .Should().HaveCount(1)
+                .And.ContainSingle(x => x.NotificationClassName == "Notification1"
+                                        && x.NotificationJson == "{}"
+                                        && x.Buffer == buffer
+                                        && x.TimeQueued == now
+                                        && x.Id != Guid.Empty);
         }
 
         [Fact]
         public async Task SendNotificationAsync_CreatesNewBuffer()
         {
-            Guid bufferGovernorId = Guid.NewGuid();
-            Guid notificationPipelineId = Guid.NewGuid();
-
             await sut.Add(new SerializedNotification() { NotificationClassName = "Notification1", NotificationJson = "{}" },
                 "buffer1", DateTime.Now, "governor1", "pipeline1");
 
-            Assert.Equal(1, inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>().Count());
-            Assert.Single(inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>(),
-                x => x.Name == "buffer1"
-                && x.GovernorName == "governor1"
-                && x.PipelineName == "pipeline1");
-            Assert.Equal(1, inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>().Count());
-            Assert.Single(inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>(),
-                x => x.Buffer == inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>().First());
+            inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>()
+                .Should().HaveCount(1)
+                .And.ContainSingle(x => x.Name == "buffer1"
+                                                 && x.GovernorName == "governor1"
+                                                 && x.PipelineName == "pipeline1");
+
+            inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>()
+                .Should().HaveCount(1);
+            inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>()
+                .Should().ContainSingle(x => x.Buffer == inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>().First());
+        }
+
+        [Fact]
+        public async Task SendNotificationAsync_CreatesBufferOnce()
+        {
+            await sut.Add(new SerializedNotification() { NotificationClassName = "Notification1", NotificationJson = "{}" },
+                "buffer1", DateTime.Now, "governor1", "pipeline1");
+            await sut.Add(new SerializedNotification() { NotificationClassName = "Notification1", NotificationJson = "{}" },
+                "buffer1", DateTime.Now, "governor1", "pipeline1");
+
+            inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>()
+                .Should().HaveCount(1)
+                .And.ContainSingle(x => x.Name == "buffer1"
+                                        && x.GovernorName == "governor1"
+                                        && x.PipelineName == "pipeline1");
+
+            inMemoryCrudRepository.FindAllWithAdded<BufferedNotification>()
+                .Should().HaveCount(2)
+                .And.OnlyContain(x => x.Buffer == inMemoryCrudRepository.FindAllWithAdded<NotificationBuffer>().First());
         }
 
         [Fact]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,23 +1,23 @@
 # RELEASE NOTES
 
-## [1.28.0] - 2020-01-27
+## [1.28.0] - 2022-01-27
 
 ### Changed
 - breaking change (notifications extension): notification buffers, pipeline and governors are now identified using arbitrary string names instead of GUIDs for more flexibility
 
-## [1.27.2] - 2020-12-15
+## [1.27.2] - 2021-12-15
 
 ### Fixed
 
 - returning null values in JsonMetadata
 
-## [1.27.1] - 2020-12-12
+## [1.27.1] - 2021-12-12
 
 ### Changed
 
 - Fixed NuGet release
 
-## [1.27.0] - 2020-12-12
+## [1.27.0] - 2021-12-12
 
 ### Added
 - CrudEntityEventToPocoProjector now sets read model TenantId from metadata of first event if no TenantAggregateRootCreated is published (e.g. for non-event sourced entities)
@@ -30,13 +30,13 @@
 
 - MetadataExtensions.GetPublishDate and GetStoreDate now return a nullable value
 
-## [1.26.1] - 2020-10-21
+## [1.26.1] - 2021-10-21
 
 ### Fixed
 
 - EasyNetQ subscription AddType configuration should provide default empty configuration callback when passed null
 
-## [1.26.0] - 2020-10-20
+## [1.26.0] - 2021-10-20
 
 ### Added
 - EasyNetQ subscriptions can now be registered as blocking (i.e. processed sequentially, waiting until the event listeners complete before processing next message)
@@ -44,22 +44,22 @@
 ### Changed
 - major version updates for dependencies: AutoMapper 10, EasyNetQ 6
 
-## [1.25.1] - 2020-07-27
+## [1.25.1] - 2021-07-27
 
 ### Fixed
 - fixed LambdaCommandBusExtensions.SendLambdaCommandAsync overloads that did not return value, added 'Async' suffix to method name for consistency
 
-## [1.25.0] - 2020-07-27
+## [1.25.0] - 2021-07-27
 
 ### Added
 - added SendLambdaCommand extension: easily executes specified lambda like it was performed by any regular command handler
 
-## [1.24.0] - 2020-06-08
+## [1.24.0] - 2021-06-08
 
 ### Changed
 - by default, event source and event queue catch-ups now don't block application startup until finished (IAsyncEventPipelineConfiguration.WaitForEventCatchUpsUponStartup)
 
-## [1.23.0] - 2020-05-19
+## [1.23.0] - 2021-05-19
 
 ### Added
 - database migration hooks - can now listen to events like DatabaseMigrationBeforeAppliedEvent, DatabaseMigrationAppliedEvent and DatabaseMigrationsCommittedEvent
@@ -78,7 +78,7 @@
 ### Improved
 - better performance when enqueueing async events & for EFCoreCrudRepository.IsAttached
 
-## [1.22.0] - 2020-04-30
+## [1.22.0] - 2021-04-30
 
 ### Added
 - added support for event serializer customization
@@ -91,12 +91,12 @@
 - breaking change: BasicEventMetadataNames moved to Revo.Core.Events
 - manually published events no longer require explicitly set event message ID
 
-## [1.21.0] - 2020-02-16
+## [1.21.0] - 2021-02-16
 
 ### Added
 - added option to rerun repeatable database migrations when their dependencies get updated (RerunRepeatableMigrationsOnDependencyUpdate - default to true)
 
-## [1.20.2] - 2020-02-12
+## [1.20.2] - 2021-02-12
 
 ### Fixed
 - JobRunner was causing AmbiguousMatchException when a job handler class implemented more IJobHandler interfaces

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## [1.28.1] - 2022-02-03
+
+### Fixed
+- fixed BufferedNotificationStore creating the same buffer multiple times
+- fixed InMemoryCrudRepository returning non-saved entries & added tests
+
 ## [1.28.0] - 2022-01-27
 
 ### Changed

--- a/Revo.DataAccess/InMemory/InMemoryCrudRepository.cs
+++ b/Revo.DataAccess/InMemory/InMemoryCrudRepository.cs
@@ -41,7 +41,8 @@ namespace Revo.DataAccess.InMemory
 
         public Task<T> GetAsync<T>(object id) where T : class
         {
-            return Task.FromResult(EntityEntries.Select(x => x.Instance).OfType<T>().First(x => HasEntityId(x, id)));
+            return Task.FromResult(EntityEntries.Select(x => x.Instance)
+                .OfType<T>().First(x => HasEntityId(x, id)));
         }
 
         public Task<T> GetAsync<T>(CancellationToken cancellationToken, object id) where T : class
@@ -73,17 +74,17 @@ namespace Revo.DataAccess.InMemory
 
         public T FirstOrDefault<T>(Expression<Func<T, bool>> predicate) where T : class
         {
-            return EntityEntries.Select(x => x.Instance).OfType<T>().FirstOrDefault(predicate.Compile());
+            return FindAll<T>().FirstOrDefault(predicate.Compile());
         }
 
         public T First<T>(Expression<Func<T, bool>> predicate) where T : class
         {
-            return EntityEntries.Select(x => x.Instance).OfType<T>().First(predicate.Compile());
+            return FindAll<T>().First(predicate.Compile());
         }
 
         public Task<T> FirstOrDefaultAsync<T>(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken)) where T : class
         {
-            return Task.FromResult(EntityEntries.Select(x => x.Instance).OfType<T>().FirstOrDefault(predicate.Compile()));
+            return Task.FromResult(FindAll<T>().FirstOrDefault(predicate.Compile()));
         }
 
         public Task<T> FirstAsync<T>(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken)) where T : class
@@ -134,11 +135,7 @@ namespace Revo.DataAccess.InMemory
 
         public Task<T[]> FindAllAsync<T>(CancellationToken cancellationToken = default(CancellationToken)) where T : class
         {
-            return Task.FromResult(EntityEntries
-                .Where(x => (x.State & EntityState.Added) == 0 && (x.State & EntityState.Detached) == 0)
-                .Select(x => x.Instance)
-                .OfType<T>()
-                .ToArray());
+            return Task.FromResult(FindAll<T>().ToArray());
         }
 
         public IEnumerable<T> FindAllWithAdded<T>() where T : class

--- a/Tests/Revo.DataAccess.Tests/InMemory/InMemoryCrudRepositoryTests.cs
+++ b/Tests/Revo.DataAccess.Tests/InMemory/InMemoryCrudRepositoryTests.cs
@@ -1,12 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using FluentAssertions;
+using Revo.DataAccess.InMemory;
+using Revo.Domain.ReadModel;
+using System;
+using Xunit;
 
 namespace Revo.DataAccess.Tests.InMemory
 {
     public class InMemoryCrudRepositoryTests
     {
+        private InMemoryCrudRepository sut = new InMemoryCrudRepository();
+        
+        [Fact]
+        public void FindAll_ReturnsAfterSaving()
+        {
+            var entity1 = new Entity1() { Id = Guid.NewGuid() };
+            sut.Add(entity1);
+            sut.SaveChanges();
+            sut.FindAll<Entity1>().Should().HaveCount(1).And.Contain(entity1);
+        }
+
+        [Fact]
+        public void FindAll_ReturnsOnlySaved()
+        {
+            var entity1 = new Entity1() { Id = Guid.NewGuid() };
+            sut.Add(entity1);
+            sut.FindAll<Entity1>().Should().BeEmpty();
+        }
+        
+        [Fact]
+        public void FirstOrDefault_ReturnsMatching()
+        {
+            var entity1 = new Entity1() { Id = Guid.NewGuid() };
+            var entity2 = new Entity1() { Id = Guid.NewGuid() };
+            sut.AddRange(new[] { entity1, entity2 });
+            sut.SaveChanges();
+            sut.FirstOrDefault<Entity1>(x => x.Id == entity1.Id).Should().Be(entity1);
+        }
+
+        [Fact]
+        public void FirstOrDefault_NullIfNotFound()
+        {
+            sut.FirstOrDefault<Entity1>(x => x.Id == Guid.NewGuid()).Should().BeNull();
+        }
+
+        [Fact]
+        public void FirstOrDefault_ReturnsOnlySaved()
+        {
+            var entity1 = new Entity1() { Id = Guid.NewGuid() };
+            sut.Add(entity1);
+            sut.FirstOrDefault<Entity1>(x => x.Id == entity1.Id).Should().BeNull();
+        }
+
+        class Entity1 : EntityReadModel {}
     }
 }


### PR DESCRIPTION
- bumped version to 1.28.1
- fixed BufferedNotificationStore creating the same buffer multiple times
- fixed InMemoryCrudRepository returning non-saved entries & added tests