### PR TITLE
upgrade to .NET 6.0 and ASP.NET Core 6.0

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.29.0</VersionPrefix>
+    <VersionPrefix>1.30.0</VersionPrefix>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/Examples/Todos/Revo.Examples.Todos.Tests/Revo.Examples.Todos.Tests.csproj
+++ b/Examples/Todos/Revo.Examples.Todos.Tests/Revo.Examples.Todos.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Examples/Todos/Revo.Examples.Todos/Revo.Examples.Todos.csproj
+++ b/Examples/Todos/Revo.Examples.Todos/Revo.Examples.Todos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <UserSecretsId>7b56d8f9-dff4-4c46-a824-b2d13b604ad4</UserSecretsId>
   </PropertyGroup>
 
@@ -12,21 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.PostgreSql" Version="1.8.0" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.10" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.9.7" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.11" />
-    <PackageReference Include="Npgsql" Version="5.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Extensions/Revo.Extensions.AutoMapper/Revo.Extensions.AutoMapper.csproj
+++ b/Extensions/Revo.Extensions.AutoMapper/Revo.Extensions.AutoMapper.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Extension for automatic discovery and registration of AutoMapper profiles.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="4.1.2" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="5.0.2" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Core\Revo.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Extensions/Revo.Extensions.History/ChangeTracking/ChangeTracker.cs
+++ b/Extensions/Revo.Extensions.History/ChangeTracking/ChangeTracker.cs
@@ -38,7 +38,7 @@ namespace Revo.Extensions.History.ChangeTracking
             Guid? entityId = null, Guid? entityClassId = null, Guid? userId = null) where T : ChangeData
         {
             var actorName = actorContext.CurrentActorName;
-            var now = Clock.Current.Now;
+            var now = Clock.Current.UtcNow;
             TrackedChange change = new TrackedChange(Guid.NewGuid(), changeData, actorName: actorName,
                 aggregateId: aggregateId, aggregateClassId: aggregateClassId,
                 entityId: entityId, entityClassId: entityClassId, changeTime: now,

--- a/Extensions/Revo.Extensions.History/Revo.Extensions.History.csproj
+++ b/Extensions/Revo.Extensions.History/Revo.Extensions.History.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 History-tracking extension package.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Folder Include="Audits\" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Include="Sql\rhi_baseline_1_mssql.sql" />
     <EmbeddedResource Include="Sql\rhi_baseline_1_pgsql.sql" />
     <EmbeddedResource Include="Sql\rhi_baseline_1_sqlite.sql" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="4.1.2" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="5.0.2" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Extensions/Revo.Extensions.Notifications/Channels/Buffering/AggregatingBufferGovernor.cs
+++ b/Extensions/Revo.Extensions.Notifications/Channels/Buffering/AggregatingBufferGovernor.cs
@@ -22,7 +22,7 @@ namespace Revo.Extensions.Notifications.Channels.Buffering
 
         public async Task<MultiValueDictionary<NotificationBuffer, BufferedNotification>> SelectNotificationsForReleaseAsync(IReadRepository readRepository)
         {
-            DateTimeOffset maxDate = Clock.Current.Now.Subtract(minTimeDelay);
+            DateTimeOffset maxDate = Clock.Current.UtcNow.Subtract(minTimeDelay);
             var notifications = readRepository.FindAll<BufferedNotification>()
                 .Where(x => x.TimeQueued <= maxDate && x.Buffer.GovernorName == Name);
             var buffers = await notifications

--- a/Extensions/Revo.Extensions.Notifications/Channels/Buffering/BufferedNotificationStartup.cs
+++ b/Extensions/Revo.Extensions.Notifications/Channels/Buffering/BufferedNotificationStartup.cs
@@ -19,7 +19,7 @@ namespace Revo.Extensions.Notifications.Channels.Buffering
 
         public void OnApplicationStarted()
         {
-            var scheduledTime = Clock.Current.Now + TimeSpan.FromMinutes(1);
+            var scheduledTime = Clock.Current.UtcNow + TimeSpan.FromMinutes(1);
             inMemoryJobScheduler.EnqeueJobAsync(new ProcessBufferedNotificationsJob(scheduledTime)).Wait();
         }
     }

--- a/Extensions/Revo.Extensions.Notifications/Channels/Buffering/BufferingNotificationChannel.cs
+++ b/Extensions/Revo.Extensions.Notifications/Channels/Buffering/BufferingNotificationChannel.cs
@@ -53,7 +53,7 @@ namespace Revo.Extensions.Notifications.Channels.Buffering
 
             var bufferId = await bufferSelector.SelectBufferIdAsync(tNotification);
             
-            await bufferedNotificationStore.Add(serialized, bufferId, Clock.Current.Now,
+            await bufferedNotificationStore.Add(serialized, bufferId, Clock.Current.UtcNow,
                 bufferGovernor.Name, notificationPipeline.Name);
         }
     }

--- a/Extensions/Revo.Extensions.Notifications/Channels/Buffering/ProcessBufferedNotificationsJobHandler.cs
+++ b/Extensions/Revo.Extensions.Notifications/Channels/Buffering/ProcessBufferedNotificationsJobHandler.cs
@@ -74,9 +74,9 @@ namespace Revo.Extensions.Notifications.Channels.Buffering
             }
 
             DateTimeOffset scheduledTime = job.ScheduledTime + TimeSpan.FromMinutes(1);
-            if (scheduledTime <= Clock.Current.Now)
+            if (scheduledTime <= Clock.Current.UtcNow)
             {
-                await inMemoryJobScheduler.EnqeueJobAsync(new ProcessBufferedNotificationsJob(Clock.Current.Now), null);
+                await inMemoryJobScheduler.EnqeueJobAsync(new ProcessBufferedNotificationsJob(Clock.Current.UtcNow), null);
             }
             else
             {

--- a/Extensions/Revo.Extensions.Notifications/Revo.Extensions.Notifications.csproj
+++ b/Extensions/Revo.Extensions.Notifications/Revo.Extensions.Notifications.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Configurable user notifications extension package.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Remove="Sql\rno_2_pgsql.sql" />
     <None Remove="Sql\rno_baseline_mssql.sql" />
     <None Remove="Sql\rno_baseline_pgsql.sql" />
     <None Remove="Sql\rno_baseline_sqlite.sql" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Include="Sql\rno_2_pgsql.sql" />
     <EmbeddedResource Include="Sql\rno_baseline_mssql.sql" />
     <EmbeddedResource Include="Sql\rno_baseline_pgsql.sql" />
     <EmbeddedResource Include="Sql\rno_baseline_sqlite.sql" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Extensions/Tests/Revo.Extensions.History.Tests/Revo.Extensions.History.Tests.csproj
+++ b/Extensions/Tests/Revo.Extensions.History.Tests/Revo.Extensions.History.Tests.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Auditing\" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Testing\Revo.Testing.csproj" />
     <ProjectReference Include="..\..\Revo.Extensions.History\Revo.Extensions.History.csproj" />

--- a/Extensions/Tests/Revo.Extensions.Notifications.Tests/Channels/Bufferring/ProcessBufferedNotificationsJobHandlerTests.cs
+++ b/Extensions/Tests/Revo.Extensions.Notifications.Tests/Channels/Bufferring/ProcessBufferedNotificationsJobHandlerTests.cs
@@ -76,7 +76,7 @@ namespace Revo.Extensions.Notifications.Tests.Channels.Bufferring
             bufferGovernor1.SelectNotificationsForReleaseAsync(inMemoryCrudRepository)
                 .Returns(notificationsToRelease);
 
-            var job = new ProcessBufferedNotificationsJob(Clock.Current.Now);
+            var job = new ProcessBufferedNotificationsJob(Clock.Current.UtcNow);
             await sut.HandleAsync(job, CancellationToken.None);
 
             notificationPipeline1.Received(1).ProcessNotificationsAsync(
@@ -107,7 +107,7 @@ namespace Revo.Extensions.Notifications.Tests.Channels.Bufferring
             bufferGovernor1.SelectNotificationsForReleaseAsync(inMemoryCrudRepository)
                 .Returns(notificationsToRelease);
 
-            var job = new ProcessBufferedNotificationsJob(Clock.Current.Now);
+            var job = new ProcessBufferedNotificationsJob(Clock.Current.UtcNow);
             await sut.HandleAsync(job, CancellationToken.None);
 
             Assert.DoesNotContain(notification1, inMemoryCrudRepository.FindAll<BufferedNotification>());

--- a/Extensions/Tests/Revo.Extensions.Notifications.Tests/Revo.Extensions.Notifications.Tests.csproj
+++ b/Extensions/Tests/Revo.Extensions.Notifications.Tests/Revo.Extensions.Notifications.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Testing\Revo.Testing.csproj" />
     <ProjectReference Include="..\..\Revo.Extensions.Notifications\Revo.Extensions.Notifications.csproj" />

--- a/Providers/AspNetCore/Revo.AspNetCore/Revo.AspNetCore.csproj
+++ b/Providers/AspNetCore/Revo.AspNetCore/Revo.AspNetCore.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Entity Framework (EF) Core data-access layer implementation.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.7.25" />
+    <PackageReference Include="Hangfire" Version="1.7.28" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Hangfire\Revo.Hangfire\Revo.Hangfire.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/AspNetCore/Tests/Revo.AspNetCore.Tests/Revo.AspNetCore.Tests.csproj
+++ b/Providers/AspNetCore/Tests/Revo.AspNetCore.Tests/Revo.AspNetCore.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -20,5 +20,5 @@
     <ProjectReference Include="..\..\Revo.AspNetCore\Revo.AspNetCore.csproj" />
   </ItemGroup>
 
-  
+
 </Project>

--- a/Providers/EF6/Revo.EF6/Revo.EF6.csproj
+++ b/Providers/EF6/Revo.EF6/Revo.EF6.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Entity Framework 6 (EF6) data access and infrastructure services.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="Properties\**" />
     <EmbeddedResource Remove="Properties\**" />
     <None Remove="Properties\**" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Configuration\" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/EF6/Tests/Revo.EF6.Tests/Revo.EF6.Tests.csproj
+++ b/Providers/EF6/Tests/Revo.EF6.Tests/Revo.EF6.Tests.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Revo.Testing\Revo.Testing.csproj" />
     <ProjectReference Include="..\..\Revo.EF6\Revo.EF6.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
@@ -19,7 +19,7 @@ namespace Revo.EFCore.DataAccess.Conventions
                 
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(property.GetColumnName().ToLowerInvariant());
+                    property.SetColumnName(property.GetColumnBaseName().ToLowerInvariant());
                 }
 
                 foreach (var key in entity.GetKeys())
@@ -34,7 +34,7 @@ namespace Revo.EFCore.DataAccess.Conventions
 
                 foreach (var index in entity.GetIndexes())
                 {
-                    index.SetName(index.GetName().ToLowerInvariant());
+                    index.SetDatabaseName(index.GetDatabaseName().ToLowerInvariant());
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/PrefixConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/PrefixConvention.cs
@@ -73,12 +73,12 @@ namespace Revo.EFCore.DataAccess.Conventions
 
                 if (propertyColumnPrefix?.Length > 0)
                 {
-                    property.SetColumnName($"{propertyColumnPrefix}_{property.GetColumnName()}");
+                    property.SetColumnName($"{propertyColumnPrefix}_{property.GetColumnBaseName()}");
                 }
 
                 if (propertyNamespacePrefix?.Length > 0)
                 {
-                    property.SetColumnName($"{propertyNamespacePrefix}_{property.GetColumnName()}");
+                    property.SetColumnName($"{propertyNamespacePrefix}_{property.GetColumnBaseName()}");
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/SnakeCaseColumnNamesConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/SnakeCaseColumnNamesConvention.cs
@@ -15,7 +15,7 @@ namespace Revo.EFCore.DataAccess.Conventions
             {
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(ToSnakeCase(property.GetColumnName()));
+                    property.SetColumnName(ToSnakeCase(property.GetColumnBaseName()));
                 }
 
                 foreach (var key in entity.GetKeys())
@@ -30,7 +30,7 @@ namespace Revo.EFCore.DataAccess.Conventions
 
                 foreach (var index in entity.GetIndexes())
                 {
-                    index.SetName(ToSnakeCase(index.GetName()));
+                    index.SetDatabaseName(ToSnakeCase(index.GetDatabaseName()));
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Query/CustomQueryDbContextOptionsExtension.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Query/CustomQueryDbContextOptionsExtension.cs
@@ -34,8 +34,8 @@ namespace Revo.EFCore.DataAccess.Query
 
             public override bool IsDatabaseProvider => false;
 
-            public override long GetServiceProviderHashCode() => 0;
-
+            public override int GetServiceProviderHashCode() => 0;
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
                 => debugInfo[nameof(CustomQueryDbContextOptionsExtension)] = "1";
 

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Query/CustomQueryProviderConfigurer.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Query/CustomQueryProviderConfigurer.cs
@@ -18,8 +18,7 @@ namespace Revo.EFCore.DataAccess.Query
         {
             this.serviceLocator = serviceLocator;
         }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "<Pending>")]
+        
         public void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             var builder = (IDbContextOptionsBuilderInfrastructure)optionsBuilder;

--- a/Providers/EFCore/Revo.EFCore/Domain/ReadModelConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/Domain/ReadModelConvention.cs
@@ -40,7 +40,7 @@ namespace Revo.EFCore.Domain
                     var originalEntity = modelBuilder.Model.GetEntityTypes().FirstOrDefault(x => x.ClrType == attr.EntityType)
                                          ?? throw new InvalidOperationException($"Cannot map {entity.ClrType} as ReadModelForEntity for {attr.EntityType} because the latter is not part of the model.");
 
-                    entity.FindProperty("Id").SetColumnName(originalEntity.FindProperty("Id").GetColumnName());
+                    entity.FindProperty("Id").SetColumnName(originalEntity.FindProperty("Id").GetColumnBaseName());
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/Revo.EFCore.csproj
+++ b/Providers/EFCore/Revo.EFCore/Revo.EFCore.csproj
@@ -1,50 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Entity Framework Core (EF Core) implementation of infrastructure services.</Description>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.10">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.11">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.11">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/EFCore/Tests/Revo.EFCore.Tests/Revo.EFCore.Tests.csproj
+++ b/Providers/EFCore/Tests/Revo.EFCore.Tests/Revo.EFCore.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,6 +24,6 @@
     <ProjectReference Include="..\..\..\..\Revo.Testing\Revo.Testing.csproj" />
     <ProjectReference Include="..\..\Revo.EFCore\Revo.EFCore.csproj" />
   </ItemGroup>
-  
+
 
 </Project>

--- a/Providers/EasyNetQ/Revo.EasyNetQ/Revo.EasyNetQ.csproj
+++ b/Providers/EasyNetQ/Revo.EasyNetQ/Revo.EasyNetQ.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Framework infrastruture package - event stores, projections, jobs, etc.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="EasyNetQ" Version="6.3.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/Revo.EasyNetQ.Tests.csproj
+++ b/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/Revo.EasyNetQ.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Providers/Hangfire/Revo.Hangfire/Revo.Hangfire.csproj
+++ b/Providers/Hangfire/Revo.Hangfire/Revo.Hangfire.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Hangfire background job support.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.7.25" />
+    <PackageReference Include="Hangfire" Version="1.7.28" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/RavenDB/Revo.RavenDB/Revo.RavenDB.csproj
+++ b/Providers/RavenDB/Revo.RavenDB/Revo.RavenDB.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 RavenDB data access and infrastructure services.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
+    <PackageReference Include="RavenDB.Client" Version="5.3.102" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Providers/Rebus/Revo.Rebus/Revo.Rebus.csproj
+++ b/Providers/Rebus/Revo.Rebus/Revo.Rebus.csproj
@@ -1,32 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Rebus (service bus) messaging integration package.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="Properties\**" />
     <EmbeddedResource Remove="Properties\**" />
     <None Remove="Properties\**" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
-    <PackageReference Include="Rebus" Version="6.6.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.3.0" />
+    <PackageReference Include="Rebus" Version="6.6.5" />
     <PackageReference Include="Rebus.Ninject" Version="4.1.0" />
     <PackageReference Include="Rebus.NLog" Version="5.0.0" />
-    <PackageReference Include="Rebus.RabbitMq" Version="7.3.0" />
+    <PackageReference Include="Rebus.RabbitMq" Version="7.3.5" />
     <PackageReference Include="Rebus.UnitOfWork" Version="6.0.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## [1.30.0] - 2022-05-10
+
+### Changed
+- Now targeting .NET 6.0 and .NET Standard 2.0 (dropping support for .NET Framework, .NET 3.1 and .NET Standard 2.0)
+- Upgraded to ASP.NET Core 6.0, Entity Framework Core 6.0, AutoMapper 11
+
 ## [1.29.0] - 2022-03-01
 
 ### Added

--- a/Revo.Core/Revo.Core.csproj
+++ b/Revo.Core/Revo.Core.csproj
@@ -3,26 +3,26 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
-Core package of the framework.</Description> 
+Core package of the framework.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Ninject" Version="3.3.4" />
+    <PackageReference Include="Ninject" Version="3.3.5" />
     <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.3.1" />
     <PackageReference Include="Ninject.Extensions.Factory" Version="3.3.3" />
-    <PackageReference Include="NLog" Version="4.7.11" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Revo.DataAccess/Revo.DataAccess.csproj
+++ b/Revo.DataAccess/Revo.DataAccess.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Data access abstractions.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Revo.Core\Revo.Core.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Revo.Domain/Revo.Domain.csproj
+++ b/Revo.Domain/Revo.Domain.csproj
@@ -3,23 +3,23 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Base domain model package.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Revo.Core\Revo.Core.csproj" />
     <ProjectReference Include="..\Revo.DataAccess\Revo.DataAccess.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Revo.Infrastructure/DataAccess/Migrations/Providers/AdoNetStubDatabaseMigrationProvider.cs
+++ b/Revo.Infrastructure/DataAccess/Migrations/Providers/AdoNetStubDatabaseMigrationProvider.cs
@@ -354,7 +354,7 @@ namespace Revo.Infrastructure.DataAccess.Migrations.Providers
                 param = dbCommand.CreateParameter();
                 param.DbType = DbType.DateTimeOffset;
                 param.ParameterName = "TimeApplied";
-                param.Value = Clock.Current.Now.UtcDateTime;
+                param.Value = Clock.Current.UtcNow.UtcDateTime;
                 dbCommand.Parameters.Add(param);
 
                 Logger.Debug($"Inserting {migration} database migration record");

--- a/Revo.Infrastructure/EventStores/EventStoreEventMessage.cs
+++ b/Revo.Infrastructure/EventStores/EventStoreEventMessage.cs
@@ -29,7 +29,7 @@ namespace Revo.Infrastructure.EventStores
                     { BasicEventMetadataNames.EventId, () => record.EventId.ToString() },
                     { BasicEventMetadataNames.StreamSequenceNumber, () => record.StreamSequenceNumber.ToString() },
                     { BasicEventMetadataNames.StoreDate, () => record.StoreDate.ToString(CultureInfo.InvariantCulture) },
-                    { BasicEventMetadataNames.PublishDate, () => Clock.Current.Now.ToString(CultureInfo.InvariantCulture) },
+                    { BasicEventMetadataNames.PublishDate, () => Clock.Current.UtcNow.ToString(CultureInfo.InvariantCulture) },
                 });
         }
 

--- a/Revo.Infrastructure/EventStores/Generic/EventStore.cs
+++ b/Revo.Infrastructure/EventStores/Generic/EventStore.cs
@@ -102,7 +102,7 @@ namespace Revo.Infrastructure.EventStores.Generic
         {
             var streamBuffer = await GetStreamBufferAsync(streamId);
             long version = streamBuffer.StreamVersion.Value + streamBuffer.UncommitedRows.Count;
-            DateTimeOffset storeDate = Clock.Current.Now;
+            DateTimeOffset storeDate = Clock.Current.UtcNow;
 
             var rows = events.Select(x =>
             {

--- a/Revo.Infrastructure/Jobs/InMemory/InMemoryJobScheduler.cs
+++ b/Revo.Infrastructure/Jobs/InMemory/InMemoryJobScheduler.cs
@@ -33,7 +33,7 @@ namespace Revo.Infrastructure.Jobs.InMemory
             }
             else
             {
-                var enqueueAt = Clock.Current.Now + timeDelay.Value;
+                var enqueueAt = Clock.Current.UtcNow + timeDelay.Value;
                 schedulerProcess.ScheduleJob(job, enqueueAt, (_, exception) => HandleError(jobInfo, exception));
             }
 
@@ -81,7 +81,7 @@ namespace Revo.Infrastructure.Jobs.InMemory
                 long maxDelay = schedulerConfiguration.MaxHandleRetryTimeoutStep.Ticks * delayMultiplier;
                 TimeSpan delay = TimeSpan.FromTicks(minDelay + retryRandom.Next(0, (int) (maxDelay - minDelay)));
 
-                DateTimeOffset enqueueAt = Clock.Current.Now + delay;
+                DateTimeOffset enqueueAt = Clock.Current.UtcNow + delay;
 
                 jobInfo.AttemptNumber++;
 

--- a/Revo.Infrastructure/Jobs/InMemory/InMemoryJobSchedulerProcess.cs
+++ b/Revo.Infrastructure/Jobs/InMemory/InMemoryJobSchedulerProcess.cs
@@ -39,7 +39,7 @@ namespace Revo.Infrastructure.Jobs.InMemory
         {
             while (!unscheduledJobs.IsCompleted)
             {
-                var now = Clock.Current.Now;
+                var now = Clock.Current.UtcNow;
                 EnqueueJobs(now);
 
                 ScheduledJob scheduledJob;

--- a/Revo.Infrastructure/Revo.Infrastructure.csproj
+++ b/Revo.Infrastructure/Revo.Infrastructure.csproj
@@ -1,33 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Framework infrastruture package - event stores, projections, jobs, etc.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="LinqKit.Core" Version="1.1.26" />
+    <PackageReference Include="LinqKit.Core" Version="1.2.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Revo.Domain\Revo.Domain.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Include="Sql\rev_baseline_1_mssql.sql" />
     <EmbeddedResource Include="Sql\rev_baseline_1_pgsql.sql" />
     <EmbeddedResource Include="Sql\rev_baseline_1_sqlite.sql" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Revo.Testing/Infrastructure/EventExtensions.cs
+++ b/Revo.Testing/Infrastructure/EventExtensions.cs
@@ -29,8 +29,8 @@ namespace Revo.Testing.Infrastructure
                 if (aggregateClassId != null)
                 {
                     message.SetMetadata(BasicEventMetadataNames.AggregateClassId, aggregateClassId.ToString());
-                    message.SetMetadata(BasicEventMetadataNames.StoreDate, Clock.Current.Now.ToString(CultureInfo.InvariantCulture));
-                    message.SetMetadata(BasicEventMetadataNames.PublishDate, Clock.Current.Now.ToString(CultureInfo.InvariantCulture));
+                    message.SetMetadata(BasicEventMetadataNames.StoreDate, Clock.Current.UtcNow.ToString(CultureInfo.InvariantCulture));
+                    message.SetMetadata(BasicEventMetadataNames.PublishDate, Clock.Current.UtcNow.ToString(CultureInfo.InvariantCulture));
                 }
                 return message;
             }).ToList();

--- a/Revo.Testing/Infrastructure/FakeEventStoreRecord.cs
+++ b/Revo.Testing/Infrastructure/FakeEventStoreRecord.cs
@@ -12,6 +12,6 @@ namespace Revo.Testing.Infrastructure
         public IReadOnlyDictionary<string, string> AdditionalMetadata { get; set; } = new Dictionary<string, string>();
         public Guid EventId { get; set; } = Guid.NewGuid();
         public long StreamSequenceNumber { get; set; }
-        public DateTimeOffset StoreDate { get; set; } = Clock.Current.Now;
+        public DateTimeOffset StoreDate { get; set; } = Clock.Current.UtcNow;
     }
 }

--- a/Revo.Testing/Revo.Testing.csproj
+++ b/Revo.Testing/Revo.Testing.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
 Infrastructure for testing framework apps.</Description>
     <IsTestProject>False</IsTestProject>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/Tests/Revo.Core.Tests/Revo.Core.Tests.csproj
+++ b/Tests/Revo.Core.Tests/Revo.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
@@ -11,22 +11,22 @@
     <EmbeddedResource Remove="Core\**" />
     <None Remove="Core\**" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Core\Revo.Core.csproj" />
     <ProjectReference Include="..\..\Revo.Testing\Revo.Testing.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Tests/Revo.DataAccess.Tests/Revo.DataAccess.Tests.csproj
+++ b/Tests/Revo.DataAccess.Tests/Revo.DataAccess.Tests.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.DataAccess\Revo.DataAccess.csproj" />
     <ProjectReference Include="..\..\Revo.Testing\Revo.Testing.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Tests/Revo.Domain.Tests/Revo.Domain.Tests.csproj
+++ b/Tests/Revo.Domain.Tests/Revo.Domain.Tests.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Domain\Revo.Domain.csproj" />
     <ProjectReference Include="..\..\Revo.Testing\Revo.Testing.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Tests/Revo.Infrastructure.Tests/DataAccess/Migrations/DatabaseMigrationSelectorTests.cs
+++ b/Tests/Revo.Infrastructure.Tests/DataAccess/Migrations/DatabaseMigrationSelectorTests.cs
@@ -573,7 +573,7 @@ namespace Revo.Infrastructure.Tests.DataAccess.Migrations
                     {
                         ModuleName = "appModule1",
                         Checksum = "xyz",
-                        TimeApplied = Clock.Current.Now
+                        TimeApplied = Clock.Current.UtcNow
                     }
                 });
 
@@ -603,7 +603,7 @@ namespace Revo.Infrastructure.Tests.DataAccess.Migrations
                     {
                         ModuleName = "appModule1",
                         Checksum = "abc",
-                        TimeApplied = Clock.Current.Now
+                        TimeApplied = Clock.Current.UtcNow
                     }
                 });
 
@@ -637,7 +637,7 @@ namespace Revo.Infrastructure.Tests.DataAccess.Migrations
                     {
                         ModuleName = "view",
                         Checksum = "xyz",
-                        TimeApplied = Clock.Current.Now
+                        TimeApplied = Clock.Current.UtcNow
                     }
                 });
 

--- a/Tests/Revo.Infrastructure.Tests/EventStores/Generic/EventStoreTests.cs
+++ b/Tests/Revo.Infrastructure.Tests/EventStores/Generic/EventStoreTests.cs
@@ -65,12 +65,12 @@ namespace Revo.Infrastructure.Tests.EventStores.Generic
 
             eventStreamRows = new[]
             {
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":1}", "EventName", 5, eventStreams[0].Id, 1, Clock.Current.Now, "{\"doh\":\"1\"}"),
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":2}", "EventName", 5, eventStreams[0].Id, 2, Clock.Current.Now, "{\"doh\":\"2\"}"),
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":3}", "EventName", 5, eventStreams[1].Id, 3, Clock.Current.Now, "{\"doh\":\"3\"}"),
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":4}", "EventName", 5, eventStreams[1].Id, 2, Clock.Current.Now, "{\"doh\":\"4\"}"),
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":5}", "EventName", 5, eventStreams[1].Id, 4, Clock.Current.Now, "{\"doh\":\"5\"}"),
-                new EventStreamRow(Guid.NewGuid(), "{\"bar\":6}", "EventName", 5, eventStreams[1].Id, 5, Clock.Current.Now, "{\"doh\":\"6\"}")
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":1}", "EventName", 5, eventStreams[0].Id, 1, Clock.Current.UtcNow, "{\"doh\":\"1\"}"),
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":2}", "EventName", 5, eventStreams[0].Id, 2, Clock.Current.UtcNow, "{\"doh\":\"2\"}"),
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":3}", "EventName", 5, eventStreams[1].Id, 3, Clock.Current.UtcNow, "{\"doh\":\"3\"}"),
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":4}", "EventName", 5, eventStreams[1].Id, 2, Clock.Current.UtcNow, "{\"doh\":\"4\"}"),
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":5}", "EventName", 5, eventStreams[1].Id, 4, Clock.Current.UtcNow, "{\"doh\":\"5\"}"),
+                new EventStreamRow(Guid.NewGuid(), "{\"bar\":6}", "EventName", 5, eventStreams[1].Id, 5, Clock.Current.UtcNow, "{\"doh\":\"6\"}")
             };
 
             expectedStoreRecords = eventStreamRows.Select((x, i) =>
@@ -186,7 +186,7 @@ namespace Revo.Infrastructure.Tests.EventStores.Generic
             newRows[0].EventName.Should().Be("EventName");
             newRows[0].EventVersion.Should().Be(5);
             newRows[0].Id.Should().NotBeEmpty();
-            newRows[0].StoreDate.Should().Be(Clock.Current.Now);
+            newRows[0].StoreDate.Should().Be(Clock.Current.UtcNow);
             newRows[0].IsDispatchedToAsyncQueues.Should().BeFalse();
             newRows[0].StreamSequenceNumber.Should().Be(3);
             newRows[0].StreamId.Should().Be(eventStreams[0].Id);
@@ -210,7 +210,7 @@ namespace Revo.Infrastructure.Tests.EventStores.Generic
             records.ElementAt(0).AdditionalMetadata.Should().Contain(uncommittedRecords[0].Metadata);
             records.ElementAt(0).Event.Should().BeEquivalentTo(uncommittedRecords[0].Event, cfg => cfg.RespectingRuntimeTypes());
             records.ElementAt(0).EventId.Should().NotBeEmpty();
-            records.ElementAt(0).StoreDate.Should().Be(Clock.Current.Now);
+            records.ElementAt(0).StoreDate.Should().Be(Clock.Current.UtcNow);
             records.ElementAt(0).StreamSequenceNumber.Should().Be(3);
         }
         

--- a/Tests/Revo.Infrastructure.Tests/Revo.Infrastructure.Tests.csproj
+++ b/Tests/Revo.Infrastructure.Tests/Revo.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Revo Framework</Authors>
   </PropertyGroup>
 
@@ -10,22 +10,22 @@
     <EmbeddedResource Remove="EventSourcing\**" />
     <None Remove="EventSourcing\**" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Revo.Infrastructure\Revo.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Revo.Testing\Revo.Testing.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Tools/Revo.Tools.DatabaseMigrator/Revo.Tools.DatabaseMigrator.csproj
+++ b/Tools/Revo.Tools.DatabaseMigrator/Revo.Tools.DatabaseMigrator.csproj
@@ -4,20 +4,20 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>revo-dbmigrate</ToolCommandName>
     <Description>Event Sourcing, CQRS and DDD framework for modern C#/.NET applications.
-.NET Core global tool for database migrations.</Description> 
+.NET Core global tool for database migrations.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.11" />
-    <PackageReference Include="Npgsql" Version="5.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '5.0.x'
+    version: '6.0.x'
 - task: DotNetCoreCLI@2
   inputs:
     command: 'custom'


### PR DESCRIPTION
* breaking changes:
- Now targeting .NET 6.0 and .NET Standard 2.0 (dropping support for .NET Framework, .NET 3.1 and .NET Standard 2.0)
- Upgraded to ASP.NET Core 6.0, Entity Framework Core 6.0, AutoMapper 11