### PR TITLE
♻️ refactor: Newtonsoft.Json to System.Text.Json

### DIFF
--- a/Extensions/Revo.Extensions.History/ChangeTracking/TrackedChangeRecordConverter.cs
+++ b/Extensions/Revo.Extensions.History/ChangeTracking/TrackedChangeRecordConverter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Revo.Extensions.History.ChangeTracking.Model;
 
 namespace Revo.Extensions.History.ChangeTracking
@@ -15,8 +15,8 @@ namespace Revo.Extensions.History.ChangeTracking
 
         public TrackedChange FromRecord(TrackedChangeRecord record)
         {
-            Type changeDataType = changeDataTypeCache.GetClrChangeDataType(record.ChangeDataClassName);
-            ChangeData changeData = (ChangeData)JsonConvert.DeserializeObject(record.ChangeDataJson, changeDataType);
+            var changeDataType = changeDataTypeCache.GetClrChangeDataType(record.ChangeDataClassName);
+            var changeData = (ChangeData)JsonSerializer.Deserialize(record.ChangeDataJson, changeDataType);
 
             return new TrackedChange(
                 record.Id,
@@ -41,7 +41,7 @@ namespace Revo.Extensions.History.ChangeTracking
                 AggregateClassId = change.AggregateClassId,
                 AggregateId = change.AggregateId,
                 ChangeDataClassName = changeDataTypeCache.GetChangeDataTypeName(change.ChangeData.GetType()),
-                ChangeDataJson = JsonConvert.SerializeObject(change.ChangeData),
+                ChangeDataJson = JsonSerializer.Serialize(change.ChangeData, change.ChangeData.GetType()),
                 ChangeTime = change.ChangeTime,
                 EntityClassId = change.EntityClassId,
                 EntityId = change.EntityId

--- a/Extensions/Tests/Revo.Extensions.History.Tests/ChangeTracking/TrackedChangeRecordConverterTests.cs
+++ b/Extensions/Tests/Revo.Extensions.History.Tests/ChangeTracking/TrackedChangeRecordConverterTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+
 using NSubstitute;
 using Revo.Extensions.History.ChangeTracking;
 using Revo.Extensions.History.ChangeTracking.Model;
@@ -67,7 +69,7 @@ namespace Revo.Extensions.History.Tests.ChangeTracking
             Assert.Equal(change.EntityId, record.EntityId);
             Assert.Equal(change.EntityClassId, record.EntityClassId);
             Assert.Equal("TestChangeData", record.ChangeDataClassName);
-            Assert.Equal("bar", JObject.Parse(record.ChangeDataJson)["Foo"]);
+            Assert.Equal("bar", JsonSerializer.Deserialize<Dictionary<string, string>>(record.ChangeDataJson)["Foo"]);
             Assert.Equal(change.ChangeTime, record.ChangeTime);
         }
         

--- a/Providers/EF6/Revo.EF6/Configuration/EF6InfrastructureConfigurationSection.cs
+++ b/Providers/EF6/Revo.EF6/Configuration/EF6InfrastructureConfigurationSection.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Revo.Core.Configuration;
 
 namespace Revo.EF6.Configuration
@@ -14,6 +14,6 @@ namespace Revo.EF6.Configuration
         public bool UseEventSourcedAggregateStore { get; set; }
         public bool UseCrudAggregateStore { get; set; }
 
-        public Func<JsonSerializerSettings, JsonSerializerSettings> CustomizeEventJsonSerializer { get; set; } = settings => settings;
+        public Func<JsonSerializerOptions, JsonSerializerOptions> CustomizeEventJsonSerializer { get; set; } = settings => settings;
     }
 }

--- a/Providers/EF6/Revo.EF6/Events/EF6EventsModule.cs
+++ b/Providers/EF6/Revo.EF6/Events/EF6EventsModule.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Ninject.Modules;
 using Revo.Core.Core;
 using Revo.DataAccess.Entities;
@@ -15,9 +15,9 @@ namespace Revo.EF6.Events
     [AutoLoadModule(false)]
     public class EF6AsyncEventsModule : NinjectModule
     {
-        private readonly Func<JsonSerializerSettings, JsonSerializerSettings> customizeEventJsonSerializer;
+        private readonly Func<JsonSerializerOptions, JsonSerializerOptions> customizeEventJsonSerializer;
 
-        public EF6AsyncEventsModule(Func<JsonSerializerSettings, JsonSerializerSettings> customizeEventJsonSerializer)
+        public EF6AsyncEventsModule(Func<JsonSerializerOptions, JsonSerializerOptions> customizeEventJsonSerializer)
         {
             this.customizeEventJsonSerializer = customizeEventJsonSerializer;
         }

--- a/Providers/EFCore/Revo.EFCore/Configuration/EFCoreInfrastructureConfigurationSection.cs
+++ b/Providers/EFCore/Revo.EFCore/Configuration/EFCoreInfrastructureConfigurationSection.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Revo.Core.Configuration;
 
 namespace Revo.EFCore.Configuration
@@ -14,6 +14,6 @@ namespace Revo.EFCore.Configuration
         public bool UseEventSourcedAggregateStore { get; set; }
         public bool UseCrudAggregateStore { get; set; }
 
-        public Func<JsonSerializerSettings, JsonSerializerSettings> CustomizeEventJsonSerializer { get; set; } = settings => settings;
+        public Func<JsonSerializerOptions, JsonSerializerOptions> CustomizeEventJsonSerializer { get; set; } = settings => settings;
     }
 }

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
@@ -19,7 +19,7 @@ namespace Revo.EFCore.DataAccess.Conventions
                 
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(property.GetColumnBaseName().ToLowerInvariant());
+                    property.SetColumnName(property.GetColumnName().ToLowerInvariant());
                 }
 
                 foreach (var key in entity.GetKeys())

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/PrefixConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/PrefixConvention.cs
@@ -52,7 +52,7 @@ namespace Revo.EFCore.DataAccess.Conventions
         {
             foreach (var property in entity.GetProperties())
             {
-                if (property.DeclaringEntityType != entity)
+                if (property.DeclaringType != entity)
                 {
                     continue;
                 }
@@ -64,7 +64,7 @@ namespace Revo.EFCore.DataAccess.Conventions
                     ?? property.FieldInfo?.DeclaringType;
                 TablePrefixAttribute clrTypePrefixAttribute;
                 if (clrDeclaringType != null
-                    && property.DeclaringEntityType.ClrType != clrDeclaringType
+                    && property.DeclaringType.ClrType != clrDeclaringType
                     && (clrTypePrefixAttribute = GetTablePrefixAttribute(clrDeclaringType)) != null) //this might happen e.g. if clrDeclaringType is abstract but not 
                 {
                     propertyNamespacePrefix = clrTypePrefixAttribute.NamespacePrefix;
@@ -73,12 +73,12 @@ namespace Revo.EFCore.DataAccess.Conventions
 
                 if (propertyColumnPrefix?.Length > 0)
                 {
-                    property.SetColumnName($"{propertyColumnPrefix}_{property.GetColumnBaseName()}");
+                    property.SetColumnName($"{propertyColumnPrefix}_{property.GetColumnName()}");
                 }
 
                 if (propertyNamespacePrefix?.Length > 0)
                 {
-                    property.SetColumnName($"{propertyNamespacePrefix}_{property.GetColumnBaseName()}");
+                    property.SetColumnName($"{propertyNamespacePrefix}_{property.GetColumnName()}");
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/SnakeCaseColumnNamesConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/SnakeCaseColumnNamesConvention.cs
@@ -15,7 +15,7 @@ namespace Revo.EFCore.DataAccess.Conventions
             {
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(ToSnakeCase(property.GetColumnBaseName()));
+                    property.SetColumnName(ToSnakeCase(property.GetColumnName()));
                 }
 
                 foreach (var key in entity.GetKeys())

--- a/Providers/EFCore/Revo.EFCore/Domain/ReadModelConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/Domain/ReadModelConvention.cs
@@ -38,7 +38,7 @@ namespace Revo.EFCore.Domain
                     var originalEntity = modelBuilder.Model.GetEntityTypes().FirstOrDefault(x => x.ClrType == attr.EntityType)
                                          ?? throw new InvalidOperationException($"Cannot map {entity.ClrType} as ReadModelForEntity for {attr.EntityType} because the latter is not part of the model.");
 
-                    entity.FindProperty("Id").SetColumnName(originalEntity.FindProperty("Id").GetColumnBaseName());
+                    entity.FindProperty("Id").SetColumnName(originalEntity.FindProperty("Id").GetColumnName());
                 }
             }
         }

--- a/Providers/EFCore/Revo.EFCore/Events/EFCoreEventsModule.cs
+++ b/Providers/EFCore/Revo.EFCore/Events/EFCoreEventsModule.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Ninject.Modules;
 using Revo.Core.Core;
 using Revo.Infrastructure;
@@ -13,9 +13,9 @@ namespace Revo.EFCore.Events
     [AutoLoadModule(false)]
     public class EFCoreAsyncEventsModule : NinjectModule
     {
-        private readonly Func<JsonSerializerSettings, JsonSerializerSettings> customizeEventJsonSerializer;
+        private readonly Func<JsonSerializerOptions, JsonSerializerOptions> customizeEventJsonSerializer;
 
-        public EFCoreAsyncEventsModule(Func<JsonSerializerSettings, JsonSerializerSettings> customizeEventJsonSerializer)
+        public EFCoreAsyncEventsModule(Func<JsonSerializerOptions, JsonSerializerOptions> customizeEventJsonSerializer)
         {
             this.customizeEventJsonSerializer = customizeEventJsonSerializer;
         }

--- a/Providers/EFCore/Tests/Revo.EFCore.Tests/Projections/EFCoreSyncProjectionHookTests.cs
+++ b/Providers/EFCore/Tests/Revo.EFCore.Tests/Projections/EFCoreSyncProjectionHookTests.cs
@@ -37,7 +37,7 @@ public class EFCoreSyncProjectionHookTests
 
         await sut.OnBeforeCommitAsync();
 
-        projectionSubSystem.Received(1).ExecuteProjectionsAsync(
+        await projectionSubSystem.Received(1).ExecuteProjectionsAsync(
             Arg.Is<IReadOnlyCollection<IEventMessage<DomainAggregateEvent>>>(
                 evs =>  evs.SequenceEqual(events)),
             unitOfWork,
@@ -54,15 +54,15 @@ public class EFCoreSyncProjectionHookTests
         events.Add(new TestEvent().ToMessageDraft());
         await sut.OnBeforeCommitAsync();
 
-        projectionSubSystem.ReceivedWithAnyArgs(2).ExecuteProjectionsAsync(null, null, null);
+        await projectionSubSystem.ReceivedWithAnyArgs(2).ExecuteProjectionsAsync(null, null, null);
 
-        projectionSubSystem.Received(1).ExecuteProjectionsAsync(
+        await projectionSubSystem.Received(1).ExecuteProjectionsAsync(
             Arg.Is<IReadOnlyCollection<IEventMessage<DomainAggregateEvent>>>(
                 evs => evs.SequenceEqual(new[] { events[0] })),
             unitOfWork,
             Arg.Is<EFCoreEventProjectionOptions>(x => x.IsSynchronousProjection));
 
-        projectionSubSystem.Received(1).ExecuteProjectionsAsync(
+        await projectionSubSystem.Received(1).ExecuteProjectionsAsync(
             Arg.Is<IReadOnlyCollection<IEventMessage<DomainAggregateEvent>>>(
                 evs => evs.SequenceEqual(new[] { events[1] })),
             unitOfWork,
@@ -79,7 +79,7 @@ public class EFCoreSyncProjectionHookTests
         await sut.OnCommitSucceededAsync();
         await sut.OnBeforeCommitAsync();
 
-        projectionSubSystem.Received(2).ExecuteProjectionsAsync(
+        await projectionSubSystem.Received(2).ExecuteProjectionsAsync(
             Arg.Is<IReadOnlyCollection<IEventMessage<DomainAggregateEvent>>>(
                 evs => evs.SequenceEqual(events)),
             unitOfWork,
@@ -96,7 +96,7 @@ public class EFCoreSyncProjectionHookTests
         await sut.OnCommitFailedAsync();
         await sut.OnBeforeCommitAsync();
 
-        projectionSubSystem.Received(2).ExecuteProjectionsAsync(
+        await projectionSubSystem.Received(2).ExecuteProjectionsAsync(
             Arg.Is<IReadOnlyCollection<IEventMessage<DomainAggregateEvent>>>(
                 evs => evs.SequenceEqual(events)),
             unitOfWork,

--- a/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EasyNetQBusTests.cs
+++ b/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EasyNetQBusTests.cs
@@ -38,7 +38,7 @@ namespace Revo.EasyNetQ.Tests
             
             await sut.PublishAsync(event1);
 
-            pubSub.Received(1).PublishAsync(Arg.Is<IEventMessage<Event1>>(
+            await pubSub.Received(1).PublishAsync(Arg.Is<IEventMessage<Event1>>(
                 x => x.GetType().IsConstructedGenericType
                      && x.GetType().GetGenericTypeDefinition() == typeof(EventMessage<>)
                      && x.Event == event1
@@ -56,7 +56,7 @@ namespace Revo.EasyNetQ.Tests
 
             await sut.PublishAsync(message);
 
-            pubSub.Received(1).PublishAsync(Arg.Is<IEventMessage<Event1>>(
+            await pubSub.Received(1).PublishAsync(Arg.Is<IEventMessage<Event1>>(
                 x => x.GetType().IsConstructedGenericType
                      && x.GetType().GetGenericTypeDefinition() == typeof(EventMessage<>)
                      && x.Event == event1

--- a/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EasyNetQSubscriptionHandlerTests.cs
+++ b/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EasyNetQSubscriptionHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Revo.EasyNetQ.Tests
 
             await sut.HandleMessageAsync(eventMessage);
 
-            eventBus.Received(1).PublishAsync(eventMessage);
+            await eventBus.Received(1).PublishAsync(eventMessage);
             currentTaskContext.Should().NotBeNull();
             currentTaskContext.Should().NotBe(prevTaskContext);
         }

--- a/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EventTransportTests.cs
+++ b/Providers/EasyNetQ/Tests/Revo.EasyNetQ.Tests/EventTransportTests.cs
@@ -24,7 +24,7 @@ namespace Revo.EasyNetQ.Tests
             var message = (IEventMessage<Event2>) EventMessage.FromEvent(new Event2(), new Dictionary<string, string>());
             await sut.HandleAsync(message, CancellationToken.None);
 
-            easyNetQBus.Received(1).PublishAsync<Event1>(message);
+            await easyNetQBus.Received(1).PublishAsync<Event1>(message);
         }
 
         private class Event1 : IEvent

--- a/Revo.Core/Events/JsonMetadata.cs
+++ b/Revo.Core/Events/JsonMetadata.cs
@@ -2,15 +2,16 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Revo.Core.Events
 {
     public class JsonMetadata : IReadOnlyDictionary<string, string>
     {
-        private readonly JObject jsonMetadata;
+        private readonly JsonObject jsonMetadata;
 
-        public JsonMetadata(JObject jsonMetadata)
+        public JsonMetadata(JsonObject jsonMetadata)
         {
             this.jsonMetadata = jsonMetadata;
         }
@@ -36,9 +37,9 @@ namespace Revo.Core.Events
 
         public bool TryGetValue(string key, out string value)
         {
-            if (jsonMetadata.TryGetValue(key, out JToken token))
+            if (jsonMetadata.TryGetPropertyValue(key, out JsonNode token))
             {
-                value = token.Type != JTokenType.Null ? token.ToString() : null;
+                value = token?.ToString();
                 return true;
             }
 
@@ -48,7 +49,7 @@ namespace Revo.Core.Events
 
         public string this[string key] => jsonMetadata[key]?.ToString() ?? throw new ArgumentException($"JSON metadata key not found: {key}");
 
-        public IEnumerable<string> Keys => jsonMetadata.Properties().Select(x => x.Name);
-        public IEnumerable<string> Values => jsonMetadata.PropertyValues().Select(x => x.ToString());
+        public IEnumerable<string> Keys => jsonMetadata.Select(x => x.Key);
+        public IEnumerable<string> Values => jsonMetadata.Select(x => x.Value.ToString());
     }
 }

--- a/Revo.Core/Revo.Core.csproj
+++ b/Revo.Core/Revo.Core.csproj
@@ -13,11 +13,11 @@ Core package of the framework.</Description>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Ninject" Version="3.3.6" />
     <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.3.1" />
     <PackageReference Include="Ninject.Extensions.Factory" Version="3.3.3" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Revo.Core/ValueObjects/SingleValueObject.cs
+++ b/Revo.Core/ValueObjects/SingleValueObject.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Revo.Core.ValueObjects
 {

--- a/Revo.Domain/Events/DomainEvent.cs
+++ b/Revo.Domain/Events/DomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using Revo.Core.Events;
 
 namespace Revo.Domain.Events
@@ -7,7 +7,7 @@ namespace Revo.Domain.Events
     {
         public override string ToString()
         {
-            return $"{this.GetType().FullName} : {JsonConvert.SerializeObject(this)}";
+            return $"{GetType().FullName} : {JsonSerializer.Serialize(this, GetType())}";
         }
     }
 }

--- a/Revo.Domain/Revo.Domain.csproj
+++ b/Revo.Domain/Revo.Domain.csproj
@@ -11,6 +11,7 @@ Base domain model package.</Description>
 
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Revo.Infrastructure/EventStores/Generic/Model/EventStream.cs
+++ b/Revo.Infrastructure/EventStores/Generic/Model/EventStream.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.IO;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Revo.Core.Events;
 using Revo.DataAccess.Entities;
 
@@ -14,7 +14,7 @@ namespace Revo.Infrastructure.EventStores.Generic.Model
     public class EventStream : IRowVersioned, IHasId<Guid>
     {
         private IReadOnlyDictionary<string, string> metadata;
-        private JObject metadataJsonObject;
+        private JsonObject metadataJsonObject;
 
         public EventStream(Guid id)
         {
@@ -41,8 +41,8 @@ namespace Revo.Infrastructure.EventStores.Generic.Model
                         try
                         {
                             metadataJsonObject = MetadataJson?.Length > 0
-                                ? JObject.Parse(MetadataJson)
-                                : new JObject();
+                                ? JsonObject.Parse(MetadataJson).AsObject()
+                                : [];
                         }
                         catch (JsonException e)
                         {
@@ -58,13 +58,13 @@ namespace Revo.Infrastructure.EventStores.Generic.Model
 
             set
             {
-                metadataJsonObject = new JObject();
+                metadataJsonObject = [];
                 foreach (var pair in value)
                 {
                     metadataJsonObject[pair.Key] = pair.Value;
                 }
 
-                MetadataJson = metadataJsonObject.ToString(Formatting.None);
+                MetadataJson = metadataJsonObject.ToString();
                 metadata = new JsonMetadata(metadataJsonObject);
             }
         }

--- a/Revo.Infrastructure/Events/Async/AsyncEventProcessingException.cs
+++ b/Revo.Infrastructure/Events/Async/AsyncEventProcessingException.cs
@@ -16,9 +16,5 @@ namespace Revo.Infrastructure.Events.Async
         public AsyncEventProcessingException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected AsyncEventProcessingException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/Revo.Infrastructure/Events/Async/AsyncEventProcessingSequenceException.cs
+++ b/Revo.Infrastructure/Events/Async/AsyncEventProcessingSequenceException.cs
@@ -20,10 +20,6 @@ namespace Revo.Infrastructure.Events.Async
             LastSequenceNumberProcessed = lastSequenceNumberProcessed;
         }
 
-        protected AsyncEventProcessingSequenceException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
-
         public long? LastSequenceNumberProcessed { get; }
     }
 }

--- a/Revo.Infrastructure/Validation/CommandValidationException.cs
+++ b/Revo.Infrastructure/Validation/CommandValidationException.cs
@@ -16,9 +16,5 @@ namespace Revo.Infrastructure.Validation
         public CommandValidationException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected CommandValidationException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/Tests/Revo.Core.Tests/Events/JsonMetadataTests.cs
+++ b/Tests/Revo.Core.Tests/Events/JsonMetadataTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using Revo.Core.Events;
 using Xunit;
 
@@ -9,13 +9,15 @@ namespace Revo.Core.Tests.Events
     public class JsonMetadataTests
     {
         private JsonMetadata sut;
-        private JObject json;
+        private JsonObject json;
 
         public JsonMetadataTests()
         {
-            json = new JObject();
-            json["key1"] = "value1";
-            json["key2"] = "value2";
+            json = new JsonObject
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2"
+            };
 
             sut = new JsonMetadata(json);
         }

--- a/Tests/Revo.Core.Tests/ValueObjects/SingleValueObjectTests.cs
+++ b/Tests/Revo.Core.Tests/ValueObjects/SingleValueObjectTests.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
 using Revo.Core.ValueObjects;
 using Xunit;
 
@@ -13,21 +13,22 @@ namespace Revo.Core.Tests.ValueObjects
         {
             var value = new MyValue("hello");
 
-            string json = JsonConvert.SerializeObject(value);
-            JToken jtoken = JToken.Parse(json);
+            var json = JsonSerializer.Serialize(value);
+            var jdoc = JsonDocument.Parse(json);
 
-            jtoken.Type.Should().Be(JTokenType.String);
-            jtoken.Value<string>().Should().Be("hello");
+            jdoc.RootElement.ValueKind.Should().Be(JsonValueKind.String);
+            jdoc.RootElement.GetString().Should().Be("hello");
         }
 
         [Fact]
         public void JsonDeserializesAsSingleValue()
         {
             string json = "\"hello\"";
-            MyValue value = JsonConvert.DeserializeObject<MyValue>(json);
+            var value = JsonSerializer.Deserialize<MyValue>(json);
             value.Value.Should().Be("hello");
         }
 
+        [JsonConverter(typeof(SingleValueObjectJsonConverter))]
         public class MyValue : SingleValueObject<MyValue, string>
         {
             public MyValue(string value) : base(value)


### PR DESCRIPTION
# Overview
This swaps out `Newtonsoft.Json` for the core library's `System.Text.Json` implementation.

# Breaking changes
* `System.Text.Json` does not read class attributes when inheriting a class. This means you'll need to add the `[JsonConverter(typeof(SingleValueObjectJsonConverter))]` attribute to any class that derives from `SingleValueObject`. One alternative would be to register a default json config and pull when setting up a serializer.