### PR TITLE
fixed LowerCaseConvention null reference exceptions when key names are null

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.36.0</VersionPrefix>
+    <VersionPrefix>1.36.1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
+++ b/Providers/EFCore/Revo.EFCore/DataAccess/Conventions/LowerCaseConvention.cs
@@ -14,27 +14,27 @@ namespace Revo.EFCore.DataAccess.Conventions
             {
                 if (entity.BaseType == null)
                 {
-                    entity.SetTableName(entity.GetTableName().ToLowerInvariant());
+                    entity.SetTableName(entity.GetTableName()?.ToLowerInvariant());
                 }
                 
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(property.GetColumnBaseName().ToLowerInvariant());
+                    property.SetColumnName(property.GetColumnBaseName()?.ToLowerInvariant());
                 }
 
                 foreach (var key in entity.GetKeys())
                 {
-                    key.SetName(key.GetName().ToLowerInvariant());
+                    key.SetName(key.GetName()?.ToLowerInvariant());
                 }
 
                 foreach (var key in entity.GetForeignKeys())
                 {
-                    key.SetConstraintName(key.GetConstraintName().ToLowerInvariant());
+                    key.SetConstraintName(key.GetConstraintName()?.ToLowerInvariant());
                 }
 
                 foreach (var index in entity.GetIndexes())
                 {
-                    index.SetDatabaseName(index.GetDatabaseName().ToLowerInvariant());
+                    index.SetDatabaseName(index.GetDatabaseName()?.ToLowerInvariant());
                 }
             }
         }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## [1.36.1] - 2024-11-07
+
+### Fixed
+- fixed LowerCaseConvention null reference exceptions when key names were null (e.g. with owned types)
+
 ## [1.36.0] - 2024-06-24
 
 ### Fixed


### PR DESCRIPTION
-fixed LowerCaseConvention null reference exceptions when key names were null (e.g. with owned types)
-bumped to 1.36.1