### PR TITLE
fixed repeatable migrations not being transitively reapplied on depen…

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.38.1</VersionPrefix>
+    <VersionPrefix>1.38.2</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # RELEASE NOTES
 
+## [1.38.2] - 2026-05-29
+-fixed repeatable SQL migrations not being transitively reapplied when a (transitive) dependency changed; repeatable modules are now ordered dependencies-first using the active tag-compatible variant
+
 ## [1.38.1] - 2026-01-30
 -fixed IDatabaseInitializerLoader.EnsureDatabaseInitialized thread-safety (added a lock)
 -removed xunit dependency from Revo.Testing

--- a/Revo.Infrastructure/DataAccess/Migrations/DatabaseMigrationSelector.cs
+++ b/Revo.Infrastructure/DataAccess/Migrations/DatabaseMigrationSelector.cs
@@ -27,8 +27,14 @@ namespace Revo.Infrastructure.DataAccess.Migrations
                 var result = new List<SelectedModuleMigrations>();
                 history = await migrationProvider.GetMigrationHistoryAsync();
 
-                // select migrations for modules, repeatable and unversioned last
-                var sortedModules = modules.OrderBy(x => IsRepeatableMigration(x) ? 1 : 0);
+                // select migrations for modules, repeatable and unversioned last;
+                // repeatables are additionally ordered so that dependencies are processed
+                // before their dependents - this ensures that an updated dependency is already
+                // queued when a (possibly transitively) dependent repeatable is evaluated for rerun
+                var versionedModules = modules.Where(x => !IsRepeatableMigration(x));
+                var repeatableModules = SortRepeatablesByDependencies(
+                    modules.Where(IsRepeatableMigration).ToList(), tags);
+                var sortedModules = versionedModules.Concat(repeatableModules);
 
                 foreach (var module in sortedModules)
                 {
@@ -46,6 +52,61 @@ namespace Revo.Infrastructure.DataAccess.Migrations
             {
                 history = null;
             }
+        }
+
+        // Orders repeatable modules so that a module's dependencies (that are themselves part of
+        // the requested module set) appear before it. Dependencies outside the set are ignored
+        // (versioned dependencies are processed earlier; repeatables not requested are not rerun).
+        // Cycles are tolerated and broken at an arbitrary point to avoid infinite recursion -
+        // cyclic dependencies are an invalid configuration that the registry is expected to reject.
+        private List<DatabaseMigrationSpecifier> SortRepeatablesByDependencies(
+            IReadOnlyCollection<DatabaseMigrationSpecifier> repeatableModules, string[] tags)
+        {
+            var modulesByName = new Dictionary<string, DatabaseMigrationSpecifier>(
+                StringComparer.InvariantCultureIgnoreCase);
+            foreach (var module in repeatableModules)
+            {
+                modulesByName[module.ModuleName] = module;
+            }
+
+            var sorted = new List<DatabaseMigrationSpecifier>();
+            // marking a module visited on entry (before recursing into its dependencies) also
+            // breaks any dependency cycle at an arbitrary point, preventing infinite recursion
+            var visited = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+            void Visit(DatabaseMigrationSpecifier module)
+            {
+                if (!visited.Add(module.ModuleName))
+                {
+                    return;
+                }
+
+                // pick the same tag-compatible migration that SelectModuleMigrationsNoDependenciesAsync
+                // will select, so the ordering uses the dependencies that actually apply for these tags
+                var migration = migrationRegistry.Migrations
+                    .FirstOrDefault(x => string.Equals(x.ModuleName, module.ModuleName,
+                                             StringComparison.InvariantCultureIgnoreCase)
+                                         && x.Tags.All(tagGroup => tags.Any(tagGroup.Contains)));
+                if (migration != null)
+                {
+                    foreach (var dependency in migration.Dependencies)
+                    {
+                        if (modulesByName.TryGetValue(dependency.ModuleName, out var dependencyModule))
+                        {
+                            Visit(dependencyModule);
+                        }
+                    }
+                }
+
+                sorted.Add(module);
+            }
+
+            foreach (var module in repeatableModules)
+            {
+                Visit(module);
+            }
+
+            return sorted;
         }
 
         private bool IsRepeatableMigration(DatabaseMigrationSpecifier specifier)

--- a/Tests/Revo.Infrastructure.Tests/DataAccess/Migrations/DatabaseMigrationSelectorTests.cs
+++ b/Tests/Revo.Infrastructure.Tests/DataAccess/Migrations/DatabaseMigrationSelectorTests.cs
@@ -734,6 +734,236 @@ namespace Revo.Infrastructure.Tests.DataAccess.Migrations
         }
 
         [Fact]
+        public async Task SelectMigrationsAsync_RepeatablesRerunTransitivelyWhenDependenciesUpdated()
+        {
+            // create (changed) <- view (unchanged) <- biExportView (unchanged)
+            // updating "create" must rerun "view" AND, transitively, "biExportView"
+            migrationProvider.GetMigrationHistoryAsync()
+                .Returns(new[]
+                {
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "create",
+                        Checksum = "create-old",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "view",
+                        Checksum = "view-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "biExportView",
+                        Checksum = "biexport-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    }
+                });
+
+            migrationRegistry.Migrations.Returns(new List<IDatabaseMigration>()
+            {
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "create",
+                    IsRepeatable = true,
+                    Checksum = "create-new"
+                },
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "view",
+                    IsRepeatable = true,
+                    Checksum = "view-checksum",
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("create", null),
+                    }
+                },
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "biExportView",
+                    IsRepeatable = true,
+                    Checksum = "biexport-checksum",
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("view", null),
+                    }
+                }
+            });
+
+            // intentionally pass the dependent before its dependencies to exercise ordering
+            var migrations = await sut.SelectMigrationsAsync(
+                migrationProvider,
+                new[]
+                {
+                    new DatabaseMigrationSpecifier("biExportView", null),
+                    new DatabaseMigrationSpecifier("create", null),
+                    new DatabaseMigrationSpecifier("view", null)
+                },
+                new string[0]);
+
+            migrations.Should().HaveCount(3);
+            migrations.Should().Contain(x => x.Specifier.Equals(new DatabaseMigrationSpecifier("create", null)));
+            migrations.Should().Contain(x => x.Specifier.Equals(new DatabaseMigrationSpecifier("view", null)));
+            migrations.Should().Contain(x => x.Specifier.Equals(new DatabaseMigrationSpecifier("biExportView", null)));
+        }
+
+        [Fact]
+        public async Task SelectMigrationsAsync_RepeatablesRerunInDependencyOrderWhenDependenciesUpdated()
+        {
+            // create (changed) <- view (unchanged) <- biExportView (unchanged)
+            // the reapplied repeatables must be ordered dependencies-first
+            migrationProvider.GetMigrationHistoryAsync()
+                .Returns(new[]
+                {
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "create",
+                        Checksum = "create-old",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "view",
+                        Checksum = "view-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "biExportView",
+                        Checksum = "biexport-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    }
+                });
+
+            migrationRegistry.Migrations.Returns(new List<IDatabaseMigration>()
+            {
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "create",
+                    IsRepeatable = true,
+                    Checksum = "create-new"
+                },
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "view",
+                    IsRepeatable = true,
+                    Checksum = "view-checksum",
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("create", null),
+                    }
+                },
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "biExportView",
+                    IsRepeatable = true,
+                    Checksum = "biexport-checksum",
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("view", null),
+                    }
+                }
+            });
+
+            var migrations = await sut.SelectMigrationsAsync(
+                migrationProvider,
+                new[]
+                {
+                    new DatabaseMigrationSpecifier("biExportView", null),
+                    new DatabaseMigrationSpecifier("create", null),
+                    new DatabaseMigrationSpecifier("view", null)
+                },
+                new string[0]);
+
+            migrations.Select(x => x.Specifier.ModuleName).Should().Equal(
+                "create", "view", "biExportView");
+        }
+
+        [Fact]
+        public async Task SelectMigrationsAsync_RepeatablesRerunTransitivelyUsingTagSpecificDependencies()
+        {
+            // biExportView has a tag-specific dependency: only the DEV variant depends on "view".
+            // The ordering must use the DEV variant's dependencies for a DEV run, otherwise
+            // biExportView would be evaluated before "view" is queued and skipped incorrectly.
+            migrationProvider.GetMigrationHistoryAsync()
+                .Returns(new[]
+                {
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "create",
+                        Checksum = "create-old",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "view",
+                        Checksum = "view-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    },
+                    new FakeDatabaseMigrationRecord()
+                    {
+                        ModuleName = "biExportView",
+                        Checksum = "biexport-checksum",
+                        TimeApplied = Clock.Current.UtcNow
+                    }
+                });
+
+            migrationRegistry.Migrations.Returns(new List<IDatabaseMigration>()
+            {
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "create",
+                    IsRepeatable = true,
+                    Checksum = "create-new"
+                },
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "view",
+                    IsRepeatable = true,
+                    Checksum = "view-checksum",
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("create", null),
+                    }
+                },
+                // PROD variant registered first and WITHOUT a dependency on "view"
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "biExportView",
+                    IsRepeatable = true,
+                    Checksum = "biexport-checksum",
+                    Tags = new [] { new [] { "PROD" } }
+                },
+                // DEV variant depends on "view"
+                new FakeDatabaseMigration()
+                {
+                    ModuleName = "biExportView",
+                    IsRepeatable = true,
+                    Checksum = "biexport-checksum",
+                    Tags = new [] { new [] { "DEV" } },
+                    Dependencies = new []
+                    {
+                        new DatabaseMigrationSpecifier("view", null),
+                    }
+                }
+            });
+
+            var migrations = await sut.SelectMigrationsAsync(
+                migrationProvider,
+                new[]
+                {
+                    new DatabaseMigrationSpecifier("biExportView", null),
+                    new DatabaseMigrationSpecifier("view", null),
+                    new DatabaseMigrationSpecifier("create", null)
+                },
+                new[] { "DEV" });
+
+            migrations.Select(x => x.Specifier.ModuleName).Should().Equal(
+                "create", "view", "biExportView");
+        }
+
+        [Fact]
         public async Task SelectMigrationsAsync_RepeatablesRunLast()
         {
             migrationProvider.GetMigrationHistoryAsync()


### PR DESCRIPTION
…dency change, bumped version to 1.38.2

Repeatable migration dependents were selected in an order-dependent single pass, so a dependent (e.g. mai-bi-export-view) evaluated before its updated dependency was queued would be skipped and never reconsidered. Repeatables are now ordered dependencies-first via a topological sort that uses the active tag-compatible migration variant.